### PR TITLE
Properly kill child processes of testlets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN mkdir -p /opt/todd/agent/assets/testlets
 RUN mkdir -p /opt/todd/server/assets/testlets
 
 RUN apt-get update \
- && apt-get install -y vim curl iperf git
+ && apt-get install -y vim curl iperf git sqlite3
 
 # Install ToDD
 COPY . /go/src/github.com/toddproject/todd

--- a/comms/rabbitmq.go
+++ b/comms/rabbitmq.go
@@ -860,7 +860,9 @@ func (rmq rabbitMQComms) ListenForResponses(stopListeningForResponses *chan bool
 			// Unmarshal into BaseResponse to determine type
 			var base_msg responses.BaseResponse
 			err = json.Unmarshal(d.Body, &base_msg)
-			// TODO(mierdin): Need to handle this error
+			if err != nil {
+				log.Error("Problem unmarshalling baseresponse")
+			}
 
 			log.Debugf("Agent response received: %s", d.Body)
 
@@ -870,7 +872,9 @@ func (rmq rabbitMQComms) ListenForResponses(stopListeningForResponses *chan bool
 
 				var sasr responses.SetAgentStatusResponse
 				err = json.Unmarshal(d.Body, &sasr)
-				// TODO(mierdin): Need to handle this error
+				if err != nil {
+					log.Error("Problem unmarshalling AgentStatus")
+				}
 
 				log.Debugf("Agent %s is '%s' regarding test %s. Writing to DB.", sasr.AgentUuid, sasr.Status, sasr.TestUuid)
 				err := tdb.SetAgentTestStatus(sasr.TestUuid, sasr.AgentUuid, sasr.Status)
@@ -882,10 +886,14 @@ func (rmq rabbitMQComms) ListenForResponses(stopListeningForResponses *chan bool
 
 				var utdr responses.UploadTestDataResponse
 				err = json.Unmarshal(d.Body, &utdr)
-				// TODO(mierdin): Need to handle this error
+				if err != nil {
+					log.Error("Problem unmarshalling UploadTestDataResponse")
+				}
 
 				err = tdb.SetAgentTestData(utdr.TestUuid, utdr.AgentUuid, utdr.TestData)
-				// TODO(mierdin): Need to handle this error
+				if err != nil {
+					log.Error("Problem setting agent test data")
+				}
 
 				// Send task to the agent that says to delete the entry
 				var dtdt tasks.DeleteTestDataTask

--- a/scripts/start-containers.sh
+++ b/scripts/start-containers.sh
@@ -127,9 +127,13 @@ function runintegrationtests {
 
     dtodd run inttest-ping -y -j
 
+    dtodd run inttest-http -y -j
+
+    # Running the iperf test twice to ensure the server side is properly cleaned up
+    dtodd run inttest-iperf -y -j
     dtodd run inttest-iperf -y -j
 
-    dtodd run inttest-http -y -j
+
 
 }
 

--- a/server/testrun/testrun.go
+++ b/server/testrun/testrun.go
@@ -258,7 +258,6 @@ readyloop:
 					//...and it's also in our target group, add it to our targets map
 					if val == trObj.Spec.Target.(map[string]interface{})["name"].(string) {
 						targetStatuses[agent] = status
-						log.Error(agent)
 					}
 				}
 			}


### PR DESCRIPTION
An issue was raised in Slack that a single `iperf` test would work, but all subsequent tests would not. This was caused in part by a recent change, but also some code that has existed for a while.

This bug only occurs for testlets that are running as the "target" group in a testrun that has a targettype of "group" - in short, the agent will KILL those testlets after a certain period of time (currently the default is 30 seconds) but any child processes spawned by those testlets will stay alive as defunct "zombie" processes.

This issue is also made more likely due to the fact that the current `iperf` testlet, which is currently the only testlet that can be reasonably used in such a testrun, is also written in bash, and therefore spawning the actual `iperf` program is the only way to get this functionality. It's true that if `iperf` was a native testlet, this issue would likely not have happened - however, the new approach is preferable for those that wish to write their own testlets as I have done, in bash or another language, and wish to spawn some additional processes for their tests.

So- this PR addresses this, as well as cleans up some related code:

- Use `syscall.Kill` instead of the current approach to kill the testlets. This will not only kill the testlet, but any child process of the testlet.
- Added a second `iperf` test to the integration testing script to ensure that multiple runs of the testlet would occur without issue
- Various other housekeeping items