### PR TITLE
Clean up linting warnings

### DIFF
--- a/agent/cache/cache.go
+++ b/agent/cache/cache.go
@@ -32,13 +32,13 @@ import (
 
 func NewAgentCache(cfg config.Config) *AgentCache {
 	var ac AgentCache
-	ac.db_loc = fmt.Sprintf("%s/agent_cache.db", cfg.LocalResources.OptDir)
+	ac.dbLoc = fmt.Sprintf("%s/agent_cache.db", cfg.LocalResources.OptDir)
 	return &ac
 }
 
 type AgentCache struct {
 	// Need similar abstractions to what you did in the tasks package
-	db_loc string
+	dbLoc string
 }
 
 // TODO(mierdin): Handling errors in this package?
@@ -47,10 +47,10 @@ type AgentCache struct {
 func (ac AgentCache) Init() {
 
 	// Clean up any old cache data
-	os.Remove(ac.db_loc)
+	os.Remove(ac.dbLoc)
 
 	// Open connection
-	db, err := sql.Open("sqlite3", ac.db_loc)
+	db, err := sql.Open("sqlite3", ac.dbLoc)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/agent/cache/keyvalue.go
+++ b/agent/cache/keyvalue.go
@@ -9,9 +9,8 @@
 package cache
 
 import (
-	"fmt"
-
 	"database/sql"
+	"fmt"
 
 	log "github.com/Sirupsen/logrus"
 	_ "github.com/mattn/go-sqlite3" // This look strange but is necessary - the sqlite package is used indirectly by database/sql
@@ -20,7 +19,7 @@ import (
 // GetKeyValue will retrieve a value from the agent cache using a key string
 func (ac AgentCache) GetKeyValue(key string) string {
 	// Open connection
-	db, err := sql.Open("sqlite3", ac.db_loc)
+	db, err := sql.Open("sqlite3", ac.dbLoc)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -45,7 +44,7 @@ func (ac AgentCache) GetKeyValue(key string) string {
 func (ac AgentCache) SetKeyValue(key, value string) error {
 
 	// Open connection
-	db, err := sql.Open("sqlite3", ac.db_loc)
+	db, err := sql.Open("sqlite3", ac.dbLoc)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/agent/cache/testruns.go
+++ b/agent/cache/testruns.go
@@ -24,7 +24,7 @@ import (
 func (ac AgentCache) InsertTestRun(tr defs.TestRun) error {
 
 	// Open connection
-	db, err := sql.Open("sqlite3", ac.db_loc)
+	db, err := sql.Open("sqlite3", ac.dbLoc)
 	if err != nil {
 		log.Error(err)
 		return errors.New("Error accessing sqlite cache")
@@ -45,18 +45,18 @@ func (ac AgentCache) InsertTestRun(tr defs.TestRun) error {
 	defer stmt.Close()
 
 	// Marshal our string slices to be stored in the database
-	json_targets, err := json.Marshal(tr.Targets)
+	jsonTargets, err := json.Marshal(tr.Targets)
 	if err != nil {
 		log.Error(err)
 		return errors.New("Error marshaling testrun data into JSON")
 	}
-	json_args, err := json.Marshal(tr.Args)
+	jsonArgs, err := json.Marshal(tr.Args)
 	if err != nil {
 		log.Error(err)
 		return errors.New("Error marshaling testrun data into JSON")
 	}
 
-	_, err = stmt.Exec(tr.Uuid, tr.Testlet, string(json_args), string(json_targets))
+	_, err = stmt.Exec(tr.UUID, tr.Testlet, string(jsonArgs), string(jsonTargets))
 	if err != nil {
 		log.Error(err)
 		return errors.New("Error executing new testrun insert")
@@ -64,7 +64,7 @@ func (ac AgentCache) InsertTestRun(tr defs.TestRun) error {
 
 	tx.Commit()
 
-	log.Info("Inserted new testrun into agent cache - ", tr.Uuid)
+	log.Info("Inserted new testrun into agent cache - ", tr.UUID)
 
 	return nil
 }
@@ -75,7 +75,7 @@ func (ac AgentCache) GetTestRun(uuid string) (defs.TestRun, error) {
 	var tr defs.TestRun
 
 	// Open connection
-	db, err := sql.Open("sqlite3", ac.db_loc)
+	db, err := sql.Open("sqlite3", ac.dbLoc)
 	if err != nil {
 		log.Error(err)
 		return tr, errors.New("Error accessing sqlite cache")
@@ -92,24 +92,24 @@ func (ac AgentCache) GetTestRun(uuid string) (defs.TestRun, error) {
 	for rows.Next() {
 
 		// TODO(mierdin): This may be unnecessary - rows.Scan() might allow you to pass this in as a byteslice. Experiment with this
-		var args_json, targets_json string
+		var argsJSON, targetsJSON string
 
-		rows.Scan(&tr.Testlet, &args_json, &targets_json)
-		err = json.Unmarshal([]byte(args_json), &tr.Args)
+		rows.Scan(&tr.Testlet, &argsJSON, &targetsJSON)
+		err = json.Unmarshal([]byte(argsJSON), &tr.Args)
 		if err != nil {
 			log.Error(err)
 			return tr, errors.New("Error unmarshaling testrun data from JSON")
 		}
-		err = json.Unmarshal([]byte(targets_json), &tr.Targets)
+		err = json.Unmarshal([]byte(targetsJSON), &tr.Targets)
 		if err != nil {
 			log.Error(err)
 			return tr, errors.New("Error unmarshaling testrun data from JSON")
 		}
 	}
 
-	tr.Uuid = uuid
+	tr.UUID = uuid
 
-	log.Info("Found testrun ", tr.Uuid, " running testlet ", tr.Testlet)
+	log.Info("Found testrun ", tr.UUID, " running testlet ", tr.Testlet)
 
 	return tr, nil
 }
@@ -119,7 +119,7 @@ func (ac AgentCache) GetTestRun(uuid string) (defs.TestRun, error) {
 func (ac AgentCache) UpdateTestRunData(uuid string, testData string) error {
 
 	// Open connection
-	db, err := sql.Open("sqlite3", ac.db_loc)
+	db, err := sql.Open("sqlite3", ac.dbLoc)
 	if err != nil {
 		log.Error(err)
 		return errors.New("Error accessing sqlite cache for testrun update")
@@ -155,7 +155,7 @@ func (ac AgentCache) UpdateTestRunData(uuid string, testData string) error {
 func (ac AgentCache) DeleteTestRun(uuid string) error {
 
 	// Open connection
-	db, err := sql.Open("sqlite3", ac.db_loc)
+	db, err := sql.Open("sqlite3", ac.dbLoc)
 	if err != nil {
 		log.Error(err)
 		return errors.New("Error accessing sqlite cache for DeleteTestRun")
@@ -193,7 +193,7 @@ func (ac AgentCache) GetFinishedTestRuns() (map[string]string, error) {
 	retmap := make(map[string]string)
 
 	// Open connection
-	db, err := sql.Open("sqlite3", ac.db_loc)
+	db, err := sql.Open("sqlite3", ac.dbLoc)
 	if err != nil {
 		log.Error(err)
 		return retmap, errors.New("Error accessing sqlite cache for finished testruns")

--- a/agent/defs/defs.go
+++ b/agent/defs/defs.go
@@ -28,7 +28,7 @@ type AgentRegistry struct {
 
 // AgentAdvert is a struct for an Agent advertisement
 type AgentAdvert struct {
-	Uuid           string              `json:"Uuid"`
+	UUID           string              `json:"Uuid"`
 	DefaultAddr    string              `json:"DefaultAddr"`
 	Expires        time.Duration       `json:"Expires"`
 	LocalTime      time.Time           `json:"LocalTime"`
@@ -42,7 +42,7 @@ func (a AgentAdvert) FactSummary() string {
 
 	var keys []string
 
-	for k, _ := range a.Facts {
+	for k := range a.Facts {
 		keys = append(keys, k)
 	}
 
@@ -66,7 +66,7 @@ func (a AgentAdvert) CollectorSummary() string {
 
 	var keys []string
 
-	for k, _ := range a.FactCollectors {
+	for k := range a.FactCollectors {
 		keys = append(keys, k)
 	}
 
@@ -90,7 +90,7 @@ func (a AgentAdvert) TestletSummary() string {
 
 	var keys []string
 
-	for k, _ := range a.Testlets {
+	for k := range a.Testlets {
 		keys = append(keys, k)
 	}
 
@@ -108,7 +108,7 @@ func (a AgentAdvert) TestletSummary() string {
 	return buffer.String()
 }
 
-// JsonPP pretty-prints the facts for an agent
+// PPFacts pretty-prints the facts for an agent
 func (a AgentAdvert) PPFacts() string {
 	retjson, err := json.MarshalIndent(a.Facts, "", "    ")
 	if err != nil {

--- a/agent/defs/testruns.go
+++ b/agent/defs/testruns.go
@@ -12,7 +12,7 @@ package defs
 // Here, the "targets" property is a string slice - which means that the target type and targets have already been calculated by the server.
 // This struct is sent to a specific agent so that it has the instructions it needs to perform a test.
 type TestRun struct {
-	Uuid    string   `json:"uuid"`
+	UUID    string   `json:"uuid"`
 	Targets []string `json:"targets"`
 	Testlet string   `json:"testlet"`
 	Args    string   `json:"args"`

--- a/agent/facts/facts.go
+++ b/agent/facts/facts.go
@@ -29,8 +29,8 @@ func GetFacts(cfg config.Config) map[string][]string {
 	retFactSet := make(map[string][]string)
 
 	// this is the function that will do work on a single file during a walk
-	execute_collector := func(path string, f os.FileInfo, err error) error {
-		if f.IsDir() != true {
+	executeCollector := func(path string, f os.FileInfo, err error) error {
+		if !f.IsDir() {
 			cmd := exec.Command(path)
 
 			// Stdout buffer
@@ -46,6 +46,9 @@ func GetFacts(cfg config.Config) map[string][]string {
 
 			// Unmarshal JSON into our fact map
 			err = json.Unmarshal(cmdOutput.Bytes(), &fact)
+			if err != nil {
+				return err
+			}
 
 			// We only expect a single key in the returned fact map. Only add to fact map if this is true.
 			if len(fact) == 1 {
@@ -59,7 +62,7 @@ func GetFacts(cfg config.Config) map[string][]string {
 	}
 
 	// Perform above Walk function (execute_collector) on the collector directory
-	err := filepath.Walk(fmt.Sprintf("%s/assets/factcollectors", cfg.LocalResources.OptDir), execute_collector)
+	err := filepath.Walk(fmt.Sprintf("%s/assets/factcollectors", cfg.LocalResources.OptDir), executeCollector)
 	if err != nil {
 		log.Error("Problem running fact-gathering collector")
 	}

--- a/agent/responses/responses.go
+++ b/agent/responses/responses.go
@@ -18,6 +18,6 @@ type Response interface{}
 // are used primarily to house the JSON message for passing responses over the comms package (i.e. message queue), but may also contain important
 // dependencies of the response, such as an HTTP handler.
 type BaseResponse struct {
-	AgentUuid string `json:"agentuuid"`
+	AgentUUID string `json:"agentuuid"`
 	Type      string `json:"type"`
 }

--- a/agent/responses/setagentstatus.go
+++ b/agent/responses/setagentstatus.go
@@ -11,6 +11,6 @@ package responses
 // SetAgentStatusResponse defines this particular response.
 type SetAgentStatusResponse struct {
 	BaseResponse
-	TestUuid string `json:"TestUuid"`
+	TestUUID string `json:"TestUuid"`
 	Status   string `json:"status"`
 }

--- a/agent/responses/uploadtestdata.go
+++ b/agent/responses/uploadtestdata.go
@@ -11,6 +11,6 @@ package responses
 // UploadTestDataResponse defines this particular response.
 type UploadTestDataResponse struct {
 	BaseResponse
-	TestUuid string `json:"TestUuid"`
+	TestUUID string `json:"TestUuid"`
 	TestData string `json:"status"`
 }

--- a/agent/tasks/deletetestdata.go
+++ b/agent/tasks/deletetestdata.go
@@ -9,7 +9,6 @@
 package tasks
 
 import (
-	"errors"
 	"fmt"
 
 	log "github.com/Sirupsen/logrus"
@@ -23,7 +22,7 @@ import (
 type DeleteTestDataTask struct {
 	BaseTask
 	Config   config.Config `json:"-"`
-	TestUuid string        `json:"key"`
+	TestUUID string        `json:"key"`
 }
 
 // Run contains the logic necessary to perform this task on the agent.
@@ -31,11 +30,11 @@ func (dtdt DeleteTestDataTask) Run() error {
 
 	var ac = cache.NewAgentCache(dtdt.Config)
 
-	err := ac.DeleteTestRun(dtdt.TestUuid)
+	err := ac.DeleteTestRun(dtdt.TestUUID)
 	if err != nil {
-		return errors.New(fmt.Sprintf("DeleteTestDataTask failed - %s", dtdt.TestUuid))
+		return fmt.Errorf("DeleteTestDataTask failed - %s", dtdt.TestUUID)
 	}
-	log.Info(fmt.Sprintf("DeleteTestDataTask successful - %s", dtdt.TestUuid))
+	log.Infof("DeleteTestDataTask successful - %s", dtdt.TestUUID)
 
 	return nil
 }

--- a/agent/tasks/downloadasset.go
+++ b/agent/tasks/downloadasset.go
@@ -36,14 +36,14 @@ func (dat DownloadAssetTask) Run() error {
 	// Iterate over the slice of collectors and download them.
 	for x := range dat.Assets {
 
-		assetUrl := dat.Assets[x]
+		assetURL := dat.Assets[x]
 
 		assetDir := ""
 
 		switch {
-		case strings.Contains(assetUrl, "factcollectors"):
+		case strings.Contains(assetURL, "factcollectors"):
 			assetDir = dat.CollectorDir
-		case strings.Contains(assetUrl, "testlets"):
+		case strings.Contains(assetURL, "testlets"):
 			assetDir = dat.TestletDir
 		default:
 			errorMsg := "Invalid asset download URL received"
@@ -51,7 +51,7 @@ func (dat DownloadAssetTask) Run() error {
 			return errors.New(errorMsg)
 		}
 
-		err := dat.downloadAsset(assetUrl, assetDir)
+		err := dat.downloadAsset(assetURL, assetDir)
 		if err != nil {
 			log.Error(err)
 			return err
@@ -72,19 +72,18 @@ func (dat DownloadAssetTask) downloadAsset(url, directory string) error {
 	// TODO: What if this already exists? Consider checking file existence first with io.IsExist?
 	output, err := dat.Fs.Create(fileName)
 	if err != nil {
-		return errors.New(fmt.Sprintf("Error while creating", fileName, "-", err))
+		return fmt.Errorf("Error while creating %s - %v", fileName, err)
 	}
 	defer output.Close()
 
 	response, err := dat.HTTPClient.Get(url)
-	defer response.Body.Close()
 	if err != nil || response.StatusCode != 200 {
-
 		// If we have a problem retrieving the testlet, we want to return immediately,
 		// instead of writing an empty file to disk
-		log.Error(fmt.Sprintf("Error while downloading '%s': %s", url, response.Status))
+		log.Errorf("Error while downloading '%s': %s", url, response.Status)
 		return err
 	}
+	defer response.Body.Close()
 
 	n, err := dat.Ios.Copy(output, response.Body)
 	if err != nil {

--- a/agent/tasks/downloadasset.go
+++ b/agent/tasks/downloadasset.go
@@ -77,13 +77,18 @@ func (dat DownloadAssetTask) downloadAsset(url, directory string) error {
 	defer output.Close()
 
 	response, err := dat.HTTPClient.Get(url)
-	if err != nil || response.StatusCode != 200 {
+	if err != nil {
 		// If we have a problem retrieving the testlet, we want to return immediately,
 		// instead of writing an empty file to disk
-		log.Errorf("Error while downloading '%s': %s", url, response.Status)
+		log.Errorf("Error while downloading '%s': %v", url, err)
 		return err
 	}
 	defer response.Body.Close()
+
+	if response.StatusCode != 200 {
+		log.Errorf("Error while downloading '%s': %s", url, response.Status)
+		return err
+	}
 
 	n, err := dat.Ios.Copy(output, response.Body)
 	if err != nil {

--- a/agent/tasks/executetestrun.go
+++ b/agent/tasks/executetestrun.go
@@ -29,7 +29,7 @@ import (
 type ExecuteTestRunTask struct {
 	BaseTask
 	Config    config.Config `json:"-"`
-	TestUuid  string        `json:"testuuid"`
+	TestUUID  string        `json:"testuuid"`
 	TimeLimit int           `json:"timelimit"`
 }
 
@@ -55,13 +55,13 @@ func (ett ExecuteTestRunTask) Run() error {
 
 	// Retrieve test from cache by UUID
 	var ac = cache.NewAgentCache(ett.Config)
-	tr, err := ac.GetTestRun(ett.TestUuid)
+	tr, err := ac.GetTestRun(ett.TestUUID)
 	if err != nil {
 		log.Error(err)
 		return errors.New("Problem retrieving testrun from agent cache")
 	}
 
-	log.Debugf("IMMA FIRIN MAH LAZER (for test %s) ", ett.TestUuid)
+	log.Debugf("IMMA FIRIN MAH LAZER (for test %s) ", ett.TestUUID)
 
 	// Specify size of wait group equal to number of targets
 	wg.Add(len(tr.Targets))
@@ -134,7 +134,7 @@ func (ett ExecuteTestRunTask) Run() error {
 
 	wg.Wait()
 
-	testdata_json, err := json.Marshal(gatheredData)
+	testdataJSON, err := json.Marshal(gatheredData)
 	if err != nil {
 		log.Errorf("Failed to marshal post-test data %v", err)
 		// TODO(mierdin): This gets triggered for all iperf servers, because they don't provide metrics.
@@ -142,12 +142,12 @@ func (ett ExecuteTestRunTask) Run() error {
 	}
 
 	// Write test data to agent cache
-	err = ac.UpdateTestRunData(ett.TestUuid, string(testdata_json))
+	err = ac.UpdateTestRunData(ett.TestUUID, string(testdataJSON))
 	if err != nil {
 		log.Fatal("Failed to install post-test data into cache")
 		os.Exit(1)
 	} else {
-		log.Debugf("Wrote combined post-test data for %s to cache", ett.TestUuid)
+		log.Debugf("Wrote combined post-test data for %s to cache", ett.TestUUID)
 	}
 
 	return nil

--- a/agent/tasks/keyvalue.go
+++ b/agent/tasks/keyvalue.go
@@ -9,7 +9,6 @@
 package tasks
 
 import (
-	"errors"
 	"fmt"
 
 	log "github.com/Sirupsen/logrus"
@@ -34,9 +33,9 @@ func (kvt KeyValueTask) Run() error {
 
 	err := ac.SetKeyValue(kvt.Key, kvt.Value)
 	if err != nil {
-		return errors.New(fmt.Sprintf("KeyValueTask failed - %s:%s", kvt.Key, kvt.Value))
+		return fmt.Errorf("KeyValueTask failed - %s:%s", kvt.Key, kvt.Value)
 	}
-	log.Info(fmt.Sprintf("KeyValueTask successful - %s:%s", kvt.Key, kvt.Value))
+	log.Infof("KeyValueTask successful - %s:%s", kvt.Key, kvt.Value)
 
 	return nil
 }

--- a/agent/tasks/setgroup.go
+++ b/agent/tasks/setgroup.go
@@ -9,7 +9,6 @@
 package tasks
 
 import (
-	"errors"
 	"fmt"
 
 	log "github.com/Sirupsen/logrus"
@@ -36,11 +35,11 @@ func (sgt SetGroupTask) Run() error {
 	if ac.GetKeyValue("group") != sgt.GroupName {
 		err := ac.SetKeyValue("group", sgt.GroupName)
 		if err != nil {
-			return errors.New(fmt.Sprintf("Failed to set keyvalue pair - %s:%s", "group", sgt.GroupName))
+			return fmt.Errorf("Failed to set keyvalue pair - %s:%s", "group", sgt.GroupName)
 		}
 		err = ac.SetKeyValue("unackedGroup", "true")
 		if err != nil {
-			return errors.New(fmt.Sprintf("Failed to set keyvalue pair - %s:%s", "unackedGroup", "true"))
+			return fmt.Errorf("Failed to set keyvalue pair - %s:%s", "unackedGroup", "true")
 		}
 	} else {
 		log.Info("Already in the group being dictated by the server: ", sgt.GroupName)

--- a/api/client/agents.go
+++ b/api/client/agents.go
@@ -24,14 +24,14 @@ import (
 // Agents will query the ToDD server for a list of currently registered agents, and will display
 // a list of them to the user. Optionally, the user can provide a subargument containing the UUID of
 // a registered agent, and this function will output more detailed information about that agent.
-func (capi ClientApi) Agents(conf map[string]string, agentUuid string) ([]defs.AgentAdvert, error) {
+func (capi ClientAPI) Agents(conf map[string]string, agentUUID string) ([]defs.AgentAdvert, error) {
 
 	var agents []defs.AgentAdvert
 
 	var url string
 
-	if agentUuid != "" {
-		url = fmt.Sprintf("http://%s:%s/v1/agent?uuid=%s", conf["host"], conf["port"], agentUuid)
+	if agentUUID != "" {
+		url = fmt.Sprintf("http://%s:%s/v1/agent?uuid=%s", conf["host"], conf["port"], agentUUID)
 	} else {
 		url = fmt.Sprintf("http://%s:%s/v1/agent", conf["host"], conf["port"])
 	}
@@ -59,31 +59,27 @@ func (capi ClientApi) Agents(conf map[string]string, agentUuid string) ([]defs.A
 
 	// Marshal API data into object
 	err = json.Unmarshal(body, &agents)
-	if err != nil {
-		return agents, err
-	}
-
-	return agents, nil
+	return agents, err
 }
 
 // DisplayAgents is responsible for displaying a set of Agents to the terminal
-func (capi ClientApi) DisplayAgents(agents []defs.AgentAdvert, detail bool) error {
+func (capi ClientAPI) DisplayAgents(agents []defs.AgentAdvert, detail bool) error {
 
 	if len(agents) == 0 {
 		fmt.Println("No agents found.")
 		return nil
-	} else {
-		if agents[0].Uuid == "" {
-			fmt.Println("No agents found.")
-			return nil
-		}
+	}
+
+	if agents[0].UUID == "" {
+		fmt.Println("No agents found.")
+		return nil
 	}
 
 	if detail {
 
 		// TODO(moswalt): if nothing found, API should return either null or empty slice, and client should handle this
 		tmpl, err := template.New("test").Parse(
-			`Agent UUID:  {{.Uuid}}
+			`Agent UUID:  {{.UUID}}
 Expires:  {{.Expires}}
 Collector Summary: {{.CollectorSummary}}
 Facts:
@@ -112,7 +108,7 @@ Facts:
 			fmt.Fprintf(
 				w,
 				"%s\t%s\t%s\t%s\t%s\n",
-				hostresources.TruncateID(agents[i].Uuid),
+				hostresources.TruncateID(agents[i].UUID),
 				agents[i].Expires,
 				agents[i].DefaultAddr,
 				agents[i].FactSummary(),

--- a/api/client/agents_test.go
+++ b/api/client/agents_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 var testAgent = defs.AgentAdvert{
-	Uuid:        "aaaaaaaaaaaaaaaaaaaaaa",
+	UUID:        "aaaaaaaaaaaaaaaaaaaaaa",
 	DefaultAddr: "192.168.0.1",
 	Expires:     27000000000,
 	LocalTime:   time.Now(),
@@ -45,13 +45,13 @@ func TestAgents(t *testing.T) {
 
 	testAgentSlice := []defs.AgentAdvert{testAgent}
 
-	agentJson, err := json.Marshal(testAgentSlice)
+	agentJSON, err := json.Marshal(testAgentSlice)
 	if err != nil {
 		t.Error(err)
 	}
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Write(agentJson)
+		w.Write(agentJSON)
 	}))
 	defer ts.Close()
 
@@ -65,7 +65,7 @@ func TestAgents(t *testing.T) {
 		t.Error(err)
 	}
 
-	var capi ClientApi
+	var capi ClientAPI
 	agents, err := capi.Agents(
 		map[string]string{
 			"host": host,
@@ -93,7 +93,7 @@ var agentTests = []struct {
 
 // TestDisplayAgents iterates over the test cases and runs DisplayAgents on each
 func TestDisplayAgents(t *testing.T) {
-	var capi ClientApi
+	var capi ClientAPI
 	for _, test := range agentTests {
 		err := capi.DisplayAgents(test.arg1, test.arg2)
 		if err != nil {

--- a/api/client/client.go
+++ b/api/client/client.go
@@ -8,4 +8,4 @@
 
 package api
 
-type ClientApi struct{}
+type ClientAPI struct{}

--- a/api/client/delete.go
+++ b/api/client/delete.go
@@ -17,7 +17,7 @@ import (
 )
 
 // Delete will send a request to remove an existing ToDD Object
-func (capi ClientApi) Delete(conf map[string]string, objType, objLabel string) error {
+func (capi ClientAPI) Delete(conf map[string]string, objType, objLabel string) error {
 
 	// If insufficient subargs were provided, error out
 	if objType == "" || objLabel == "" {
@@ -34,16 +34,14 @@ func (capi ClientApi) Delete(conf map[string]string, objType, objLabel string) e
 	}
 
 	// Marshal deleteinfo into JSON
-	json_str, err := json.Marshal(deleteinfo)
+	jsonByte, err := json.Marshal(deleteinfo)
 	if err != nil {
 		return err
 	}
 
 	// Construct API request, and send POST to server for this object
-	var url string
-	url = fmt.Sprintf("http://%s:%s/v1/object/delete", conf["host"], conf["port"])
+	url := fmt.Sprintf("http://%s:%s/v1/object/delete", conf["host"], conf["port"])
 
-	var jsonByte = []byte(json_str)
 	req, err := http.NewRequest("POST", url, bytes.NewBuffer(jsonByte))
 	if err != nil {
 		return err

--- a/api/client/groups.go
+++ b/api/client/groups.go
@@ -20,7 +20,7 @@ import (
 )
 
 // Groups will query ToDD for a map containing current agent-to-group mappings
-func (capi ClientApi) Groups(conf map[string]string) error {
+func (capi ClientAPI) Groups(conf map[string]string) error {
 
 	url := fmt.Sprintf("http://%s:%s/v1/groups", conf["host"], conf["port"])
 
@@ -58,12 +58,12 @@ func (capi ClientApi) Groups(conf map[string]string) error {
 	w.Init(os.Stdout, 0, 8, 0, '\t', 0)
 	fmt.Fprintln(w, "UUID\tGROUP NAME")
 
-	for agent_uuid, group_name := range groupmap {
+	for agentUUID, groupName := range groupmap {
 		fmt.Fprintf(
 			w,
 			"%s\t%s\n",
-			hostresources.TruncateID(agent_uuid),
-			group_name,
+			hostresources.TruncateID(agentUUID),
+			groupName,
 		)
 	}
 	fmt.Fprintln(w)

--- a/api/client/objects.go
+++ b/api/client/objects.go
@@ -21,7 +21,7 @@ import (
 
 // Objects will query ToDD for all objects, with the type requested in the sub-arguments, and then display a list of those
 // objects to the user.
-func (capi ClientApi) Objects(conf map[string]string, objType string) error {
+func (capi ClientAPI) Objects(conf map[string]string, objType string) error {
 
 	// If no subarg was provided, instruct the user to provide the object type
 	if objType == "" {
@@ -51,7 +51,7 @@ func (capi ClientApi) Objects(conf map[string]string, objType string) error {
 		return err
 	}
 
-	parsed_objects := objects.ParseToddObjects(body)
+	parsedObjects := objects.ParseToddObjects(body)
 
 	w := new(tabwriter.Writer)
 
@@ -59,14 +59,14 @@ func (capi ClientApi) Objects(conf map[string]string, objType string) error {
 	w.Init(os.Stdout, 0, 8, 0, '\t', 0)
 	fmt.Fprintln(w, "LABEL\tTYPE\tSPEC\t")
 
-	for i := range parsed_objects {
+	for i := range parsedObjects {
 
 		fmt.Fprintf(
 			w,
 			"%s\t%s\t%s\n",
-			parsed_objects[i].GetLabel(),
-			parsed_objects[i].GetType(),
-			parsed_objects[i].GetSpec(),
+			parsedObjects[i].GetLabel(),
+			parsedObjects[i].GetType(),
+			parsedObjects[i].GetSpec(),
 		)
 	}
 	fmt.Fprintln(w)

--- a/api/client/run.go
+++ b/api/client/run.go
@@ -22,7 +22,7 @@ import (
 )
 
 // Run is responsible for activating an existing testrun object
-func (capi ClientApi) Run(conf map[string]string, testrunName string, displayReport, skipConfirm bool) error {
+func (capi ClientAPI) Run(conf map[string]string, testrunName string, displayReport, skipConfirm bool) error {
 
 	sourceGroup := conf["sourceGroup"]
 	sourceApp := conf["sourceApp"]
@@ -89,11 +89,11 @@ func (capi ClientApi) Run(conf map[string]string, testrunName string, displayRep
 
 	switch string(serverResponse) {
 	case "notfound":
-		return errors.New("ERROR - Specified testrun object not found.")
+		return errors.New("ERROR - Specified testrun object not found")
 	case "invalidtopology":
 		return errors.New("ERROR - Not enough agents are in the groups specified by the testrun")
 	case "failure":
-		return errors.New("ERROR - some kind of error was encountered on the server. Test was not run.")
+		return errors.New("ERROR - some kind of error was encountered on the server. Test was not run")
 	}
 
 	testUUID := string(serverResponse)

--- a/api/server/agent.go
+++ b/api/server/agent.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 
 	log "github.com/Sirupsen/logrus"
+
 	"github.com/toddproject/todd/agent/defs"
 )
 
@@ -31,7 +32,7 @@ func (tapi ToDDApi) Agent(w http.ResponseWriter, r *http.Request) {
 	if uuid := r.URL.Query().Get("uuid"); uuid != "" {
 		// Let's use the full list so we can identify the right agent if the user specified a short
 		for i := range agentList {
-			if strings.HasPrefix(agentList[i].Uuid, uuid) {
+			if strings.HasPrefix(agentList[i].UUID, uuid) {
 				// Replace agentList with first match and break
 				agentList = []defs.AgentAdvert{agentList[i]}
 				break

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -47,8 +47,8 @@ func (tapi ToDDApi) Start(cfg config.Config) error {
 	http.HandleFunc("/v1/testrun/run", tapi.Run)
 	http.HandleFunc("/v1/testdata", tapi.TestData)
 
-	serve_url := fmt.Sprintf("%s:%s", tapi.cfg.API.Host, tapi.cfg.API.Port)
+	serveURL := fmt.Sprintf("%s:%s", tapi.cfg.API.Host, tapi.cfg.API.Port)
 
-	log.Infof("Serving ToDD Server API at: %s\n", serve_url)
-	return http.ListenAndServe(serve_url, nil)
+	log.Infof("Serving ToDD Server API at: %s\n", serveURL)
+	return http.ListenAndServe(serveURL, nil)
 }

--- a/assets/assets_unpack.go
+++ b/assets/assets_unpack.go
@@ -203,10 +203,10 @@ func AssetNames() []string {
 
 // _bindata is a table, holding each asset generator, mapped to its name.
 var _bindata = map[string]func() (*asset, error){
-	"testing/bashtestlets/http": testingBashtestletsHttp,
-	"testing/bashtestlets/iperf": testingBashtestletsIperf,
+	"testing/bashtestlets/http":      testingBashtestletsHttp,
+	"testing/bashtestlets/iperf":     testingBashtestletsIperf,
 	"facts/collectors/get_addresses": factsCollectorsGet_addresses,
-	"facts/collectors/get_hostname": factsCollectorsGet_hostname,
+	"facts/collectors/get_hostname":  factsCollectorsGet_hostname,
 }
 
 // AssetDir returns the file names below a certain
@@ -248,16 +248,17 @@ type bintree struct {
 	Func     func() (*asset, error)
 	Children map[string]*bintree
 }
+
 var _bintree = &bintree{nil, map[string]*bintree{
 	"facts": &bintree{nil, map[string]*bintree{
 		"collectors": &bintree{nil, map[string]*bintree{
 			"get_addresses": &bintree{factsCollectorsGet_addresses, map[string]*bintree{}},
-			"get_hostname": &bintree{factsCollectorsGet_hostname, map[string]*bintree{}},
+			"get_hostname":  &bintree{factsCollectorsGet_hostname, map[string]*bintree{}},
 		}},
 	}},
 	"testing": &bintree{nil, map[string]*bintree{
 		"bashtestlets": &bintree{nil, map[string]*bintree{
-			"http": &bintree{testingBashtestletsHttp, map[string]*bintree{}},
+			"http":  &bintree{testingBashtestletsHttp, map[string]*bintree{}},
 			"iperf": &bintree{testingBashtestletsIperf, map[string]*bintree{}},
 		}},
 	}},
@@ -309,4 +310,3 @@ func _filePath(dir, name string) string {
 	cannonicalName := strings.Replace(name, "\\", "/", -1)
 	return filepath.Join(append([]string{dir}, strings.Split(cannonicalName, "/")...)...)
 }
-

--- a/cmd/todd-agent/assets.go
+++ b/cmd/todd-agent/assets.go
@@ -22,24 +22,22 @@ import (
 // GetLocalAssets gathers all currently installed assets, and generates a map of their names and hashes.
 func GetLocalAssets(cfg config.Config) map[string]map[string]string {
 
-	asset_types := []string{
+	assetTypes := []string{
 		"factcollectors",
 		"testlets",
 	}
 
-	final_return_assets := make(map[string]map[string]string)
+	finalReturnAssets := make(map[string]map[string]string)
 
-	for i := range asset_types {
-		found_assets := make(map[string]string)
-
-		thisType := asset_types[i]
+	for _, thisType := range assetTypes {
+		foundAssets := make(map[string]string)
 
 		// this is the function that will generate a hash for a file and add it to our asset map
-		discover_assets := func(path string, f os.FileInfo, err error) error {
+		discoverAssets := func(path string, f os.FileInfo, err error) error {
 
-			if f.IsDir() != true {
+			if !f.IsDir() {
 				// Generate hash
-				found_assets[f.Name()] = hostresources.GetFileSHA256(path)
+				foundAssets[f.Name()] = hostresources.GetFileSHA256(path)
 				log.Debugf("Asset found locally: %s (with hash %s)", f.Name(), hostresources.GetFileSHA256(path))
 			}
 			return nil
@@ -56,17 +54,17 @@ func GetLocalAssets(cfg config.Config) map[string]map[string]string {
 		}
 
 		// Perform above Walk function (discover_assets) on the collector directory
-		err = filepath.Walk(thisAssetDir, discover_assets)
+		err = filepath.Walk(thisAssetDir, discoverAssets)
 		if err != nil {
 			log.Error("Problem getting assets")
 			os.Exit(1)
 		}
 
-		final_return_assets[thisType] = found_assets
+		finalReturnAssets[thisType] = foundAssets
 
 	}
 
 	// Return collectors so that the calling function can pass this to the registry for enforcement
-	return final_return_assets
+	return finalReturnAssets
 
 }

--- a/cmd/todd-server/main.go
+++ b/cmd/todd-server/main.go
@@ -24,11 +24,10 @@ import (
 )
 
 var (
-	todd_version = "0.0.1"
+	toddVersion = "0.0.1"
+	// Command-line Arguments
+	argVersion string
 )
-
-// Command-line Arguments
-var arg_config string
 
 func init() {
 
@@ -43,7 +42,7 @@ func init() {
 		os.Exit(0)
 	}
 
-	flag.StringVar(&arg_config, "config", "/etc/todd/server.cfg", "ToDD server config file location")
+	flag.StringVar(&argVersion, "config", "/etc/todd/server.cfg", "ToDD server config file location")
 	flag.Parse()
 
 	// TODO(moswalt): Implement configurable loglevel in server and agent
@@ -52,7 +51,7 @@ func init() {
 
 func main() {
 
-	cfg, err := config.GetConfig(arg_config)
+	cfg, err := config.GetConfig(argVersion)
 	if err != nil {
 		log.Fatalf("Problem getting configuration: %v\n", err)
 	}
@@ -84,7 +83,7 @@ func main() {
 
 	go func() {
 		for {
-			err := tc.CommsPackage.ListenForAgent(assets)
+			err := tc.Package.ListenForAgent(assets)
 			if err != nil {
 				log.Fatalf("Error listening for ToDD Agents")
 			}
@@ -100,10 +99,10 @@ func main() {
 		}
 	}()
 
-	log.Infof("ToDD server v%s. Press any key to exit...\n", todd_version)
+	log.Infof("ToDD server v%s. Press any key to exit...\n", toddVersion)
 
 	// Sssh, sssh, only dreams now....
 	for {
-		time.Sleep(time.Second * 10)
+		time.Sleep(time.Second * 10) // TODO: Replace with select{}, blocks forever without interrupt
 	}
 }

--- a/cmd/todd/main.go
+++ b/cmd/todd/main.go
@@ -18,7 +18,7 @@ import (
 
 func main() {
 
-	var clientapi capi.ClientApi
+	var clientAPI capi.ClientAPI
 
 	app := cli.NewApp()
 	app.Name = "todd"
@@ -51,7 +51,7 @@ func main() {
 			Name:  "agents",
 			Usage: "Show ToDD agent information",
 			Action: func(c *cli.Context) {
-				agents, err := clientapi.Agents(
+				agents, err := clientAPI.Agents(
 					map[string]string{
 						"host": host,
 						"port": port,
@@ -62,7 +62,7 @@ func main() {
 					fmt.Println(err)
 					os.Exit(1)
 				}
-				err = clientapi.DisplayAgents(agents, !(c.Args().Get(0) == ""))
+				err = clientAPI.DisplayAgents(agents, !(c.Args().Get(0) == ""))
 				if err != nil {
 					fmt.Println("Problem displaying agents (client-side)")
 				}
@@ -75,7 +75,7 @@ func main() {
 			Usage: "Create ToDD object (group, testrun, etc.)",
 			Action: func(c *cli.Context) {
 
-				err := clientapi.Create(
+				err := clientAPI.Create(
 					map[string]string{
 						"host": host,
 						"port": port,
@@ -94,7 +94,7 @@ func main() {
 			Name:  "delete",
 			Usage: "Delete ToDD object",
 			Action: func(c *cli.Context) {
-				err := clientapi.Delete(
+				err := clientAPI.Delete(
 					map[string]string{
 						"host": host,
 						"port": port,
@@ -115,7 +115,7 @@ func main() {
 			Name:  "groups",
 			Usage: "Show current agent-to-group mappings",
 			Action: func(c *cli.Context) {
-				err := clientapi.Groups(
+				err := clientAPI.Groups(
 					map[string]string{
 						"host": host,
 						"port": port,
@@ -133,7 +133,7 @@ func main() {
 			Name:  "objects",
 			Usage: "Show information about installed group objects",
 			Action: func(c *cli.Context) {
-				err := clientapi.Objects(
+				err := clientAPI.Objects(
 					map[string]string{
 						"host": host,
 						"port": port,
@@ -174,7 +174,7 @@ func main() {
 			},
 			Usage: "Execute an already uploaded testrun object",
 			Action: func(c *cli.Context) {
-				err := clientapi.Run(
+				err := clientAPI.Run(
 					map[string]string{
 						"host":        host,
 						"port":        port,

--- a/comms/comms.go
+++ b/comms/comms.go
@@ -25,10 +25,10 @@ type assetProvider interface {
 	Assets() map[string]map[string]string
 }
 
-// CommsPackage will ensure that whatever specific comms struct is loaded at compile time will support
+// Package will ensure that whatever specific comms struct is loaded at compile time will support
 // all of the necessary features/functions that we need to make ToDD work. In short, this interface
 // represents a list of things that the server and agents do on the message queue.
-type CommsPackage interface {
+type Package interface {
 
 	// TODO(mierdin) best way to document interface or function args? I've tried to document
 	// them minimally below, but would like a better way to document the meaning behind
@@ -57,19 +57,19 @@ type CommsPackage interface {
 
 // toddComms is a struct to hold anything that satisfies the CommsPackage interface
 type toddComms struct {
-	CommsPackage
+	Package
 }
 
 // NewToDDComms will create a new instance of toddComms, and load the desired
 // CommsPackage-compatible comms package into it.
-func NewToDDComms(cfg config.Config) (*toddComms, error) {
+func NewToDDComms(cfg config.Config) (*toddComms, error) { // TODO: Return Package instead of *struct embedding Package
 
 	var tc toddComms
 
 	// Load the appropriate comms package based on config file
 	switch cfg.Comms.Plugin {
 	case "rabbitmq":
-		tc.CommsPackage = newRabbitMQComms(cfg)
+		tc.Package = newRabbitMQComms(cfg)
 	default:
 		log.Error("Invalid comms plugin in config file")
 		return nil, errors.New("Invalid comms plugin in config file")

--- a/comms/rabbitmq.go
+++ b/comms/rabbitmq.go
@@ -690,7 +690,7 @@ func (rmq rabbitMQComms) ListenForGroupTasks(groupName string, dereg chan bool) 
 			log.Debugf("Agent task received: %s", d.Body)
 
 			// call agent task method based on type
-			switch baseMsg.Type { // TODO: remove switch?
+			switch baseMsg.Type {
 
 			// This has been removed, as I am moving away from using queues that use the group name.
 

--- a/comms/rabbitmq.go
+++ b/comms/rabbitmq.go
@@ -37,7 +37,7 @@ func newRabbitMQComms(cfg config.Config) *rabbitMQComms {
 	var rmq rabbitMQComms
 	rmq.config = cfg
 
-	rmq.queueUrl = fmt.Sprintf("amqp://%s:%s@%s:%s/",
+	rmq.queueURL = fmt.Sprintf("amqp://%s:%s@%s:%s/",
 		rmq.config.Comms.User,
 		rmq.config.Comms.Password,
 		rmq.config.Comms.Host,
@@ -49,13 +49,13 @@ func newRabbitMQComms(cfg config.Config) *rabbitMQComms {
 
 type rabbitMQComms struct {
 	config   config.Config
-	queueUrl string
+	queueURL string
 }
 
 // connectRabbitMQ wraps the amqp.Dial function in order to provide connection retry functionality
-func connectRabbitMQ(queueUrl string) (*amqp.Connection, error) {
+func connectRabbitMQ(queueURL string) (*amqp.Connection, error) {
 
-	conn, err := amqp.Dial(queueUrl)
+	conn, err := amqp.Dial(queueURL)
 
 	for retries := 0; err != nil; {
 		if retries > connectRetry {
@@ -74,7 +74,7 @@ func connectRabbitMQ(queueUrl string) (*amqp.Connection, error) {
 func (rmq rabbitMQComms) AdvertiseAgent(me defs.AgentAdvert) error {
 
 	// Connect to RabbitMQ with retry logic
-	conn, err := connectRabbitMQ(rmq.queueUrl)
+	conn, err := connectRabbitMQ(rmq.queueURL)
 	if err != nil {
 		log.Error("(AdvertiseAgent) Failed to connect to RabbitMQ")
 		log.Debug(err)
@@ -134,7 +134,7 @@ func (rmq rabbitMQComms) AdvertiseAgent(me defs.AgentAdvert) error {
 	}
 
 	// Marshal agent struct to JSON
-	json_data, err := json.Marshal(me)
+	jsonData, err := json.Marshal(me)
 	if err != nil {
 		log.Error("Failed to marshal agent data from queue")
 		log.Debug(err)
@@ -149,7 +149,7 @@ func (rmq rabbitMQComms) AdvertiseAgent(me defs.AgentAdvert) error {
 		amqp.Publishing{
 			ContentType: "text/plain",
 			Expiration:  "5000", // expiration in milliseconds (we don't want these messages to pile up if the server isn't running)
-			Body:        []byte(json_data),
+			Body:        []byte(jsonData),
 		})
 	if err != nil {
 		log.Error("Failed to publish agent advertisement")
@@ -168,7 +168,7 @@ func (rmq rabbitMQComms) ListenForAgent(assets assetProvider) error {
 
 	// TODO(mierdin): does func param need to be a pointer?
 
-	conn, err := amqp.Dial(rmq.queueUrl)
+	conn, err := amqp.Dial(rmq.queueURL)
 	if err != nil {
 		log.Error("(ListenForAgent) Failed to connect to RabbitMQ")
 		log.Debug(err)
@@ -229,32 +229,32 @@ func (rmq rabbitMQComms) ListenForAgent(assets assetProvider) error {
 			var assetList []string
 
 			// assets is the asset map from the SERVER's perspective
-			for asset_type, asset_hashes := range assets.Assets() {
+			for assetType, assetHashes := range assets.Assets() {
 
 				var agentAssets map[string]string
 
 				// agentAssets is the asset map from the AGENT's perspective
-				if asset_type == "factcollectors" {
+				if assetType == "factcollectors" { // TODO: Use select
 					agentAssets = agent.FactCollectors
-				} else if asset_type == "testlets" {
+				} else if assetType == "testlets" {
 					agentAssets = agent.Testlets
 				}
 
-				for name, hash := range asset_hashes {
+				for name, hash := range assetHashes {
 
 					// See if the hashes match (a missing asset will also result in False)
 					if agentAssets[name] != hash {
 
 						// hashes do not match, so we need to append the asset download URL to the remediate list
-						var default_ip string
-						if rmq.config.LocalResources.IPAddrOverride != "" {
-							default_ip = rmq.config.LocalResources.IPAddrOverride
+						var defaultIP string
+						if rmq.config.LocalResources.IPAddrOverride != "" { // TODO: set defaultIP to override byte default and check if empty
+							defaultIP = rmq.config.LocalResources.IPAddrOverride
 						} else {
-							default_ip = hostresources.GetIPOfInt(rmq.config.LocalResources.DefaultInterface).String()
+							defaultIP = hostresources.GetIPOfInt(rmq.config.LocalResources.DefaultInterface).String()
 						}
-						asset_url := fmt.Sprintf("http://%s:%s/%s/%s", default_ip, rmq.config.Assets.Port, asset_type, name)
+						assetURL := fmt.Sprintf("http://%s:%s/%s/%s", defaultIP, rmq.config.Assets.Port, assetType, name)
 
-						assetList = append(assetList, asset_url)
+						assetList = append(assetList, assetURL)
 
 					}
 				}
@@ -286,12 +286,12 @@ func (rmq rabbitMQComms) ListenForAgent(assets assetProvider) error {
 				// }
 
 			} else {
-				log.Warnf("Agent %s did not have the required asset files. This advertisement is ignored.", agent.Uuid)
+				log.Warnf("Agent %s did not have the required asset files. This advertisement is ignored.", agent.UUID)
 
 				var task tasks.DownloadAssetTask
 				task.Type = "DownloadAsset" //TODO(mierdin): This is an extra step. Maybe a factory function for the task could help here?
 				task.Assets = assetList
-				rmq.SendTask(agent.Uuid, task)
+				rmq.SendTask(agent.UUID, task)
 			}
 		}
 	}()
@@ -306,7 +306,7 @@ func (rmq rabbitMQComms) ListenForAgent(assets assetProvider) error {
 // that have been added to a group
 func (rmq rabbitMQComms) SendTask(queueName string, task tasks.Task) error {
 
-	conn, err := amqp.Dial(rmq.queueUrl)
+	conn, err := amqp.Dial(rmq.queueURL)
 	if err != nil {
 		log.Error("(ListenForAgent) Failed to connect to RabbitMQ")
 		log.Debug(err)
@@ -364,7 +364,7 @@ func (rmq rabbitMQComms) SendTask(queueName string, task tasks.Task) error {
 		return err
 	}
 
-	json_data, err := json.Marshal(task)
+	jsonData, err := json.Marshal(task)
 	if err != nil {
 		log.Error("Failed to marshal object data")
 		log.Debug(err)
@@ -378,7 +378,7 @@ func (rmq rabbitMQComms) SendTask(queueName string, task tasks.Task) error {
 		false,           // immediate
 		amqp.Publishing{
 			ContentType: "text/plain",
-			Body:        []byte(json_data),
+			Body:        []byte(jsonData),
 		})
 	if err != nil {
 		log.Error("Failed to publish a task onto message queue")
@@ -386,7 +386,7 @@ func (rmq rabbitMQComms) SendTask(queueName string, task tasks.Task) error {
 		return err
 	}
 
-	log.Debugf("Sent task to %s: %s", queueName, json_data)
+	log.Debugf("Sent task to %s: %s", queueName, jsonData)
 
 	return nil
 }
@@ -395,7 +395,7 @@ func (rmq rabbitMQComms) SendTask(queueName string, task tasks.Task) error {
 func (rmq rabbitMQComms) ListenForTasks(uuid string) error {
 
 	// Connect to RabbitMQ with retry logic
-	conn, err := connectRabbitMQ(rmq.queueUrl)
+	conn, err := connectRabbitMQ(rmq.queueURL)
 	if err != nil {
 		log.Error("(AdvertiseAgent) Failed to connect to RabbitMQ")
 		return err
@@ -442,14 +442,14 @@ func (rmq rabbitMQComms) ListenForTasks(uuid string) error {
 		for d := range msgs {
 
 			// Unmarshal into BaseTaskMessage to determine type
-			var base_msg tasks.BaseTask
-			err = json.Unmarshal(d.Body, &base_msg)
+			var baseMsg tasks.BaseTask
+			err = json.Unmarshal(d.Body, &baseMsg)
 			// TODO(mierdin): Need to handle this error
 
 			log.Debugf("Agent task received: %s", d.Body)
 
 			// call agent task method based on type
-			switch base_msg.Type {
+			switch baseMsg.Type {
 			case "DownloadAsset":
 
 				downloadAssetTask := tasks.DownloadAssetTask{
@@ -470,42 +470,42 @@ func (rmq rabbitMQComms) ListenForTasks(uuid string) error {
 
 			case "KeyValue":
 
-				kv_task := tasks.KeyValueTask{
+				kvTask := tasks.KeyValueTask{
 					Config: rmq.config,
 				}
 
-				err = json.Unmarshal(d.Body, &kv_task)
+				err = json.Unmarshal(d.Body, &kvTask)
 				// TODO(mierdin): Need to handle this error
 
-				err = kv_task.Run()
+				err = kvTask.Run()
 				if err != nil {
 					log.Warning("The KeyValue task failed to initialize")
 				}
 
 			case "SetGroup":
 
-				sg_task := tasks.SetGroupTask{
+				sgTask := tasks.SetGroupTask{
 					Config: rmq.config,
 				}
 
-				err = json.Unmarshal(d.Body, &sg_task)
+				err = json.Unmarshal(d.Body, &sgTask)
 				// TODO(mierdin): Need to handle this error
 
-				err = sg_task.Run()
+				err = sgTask.Run()
 				if err != nil {
 					log.Warning("The SetGroup task failed to initialize")
 				}
 
 			case "DeleteTestData":
 
-				dtdt_task := tasks.DeleteTestDataTask{
+				dtdtTask := tasks.DeleteTestDataTask{
 					Config: rmq.config,
 				}
 
-				err = json.Unmarshal(d.Body, &dtdt_task)
+				err = json.Unmarshal(d.Body, &dtdtTask)
 				// TODO(mierdin): Need to handle this error
 
-				err = dtdt_task.Run()
+				err = dtdtTask.Run()
 				if err != nil {
 					log.Warning("The DeleteTestData task failed to initialize")
 				}
@@ -516,19 +516,19 @@ func (rmq rabbitMQComms) ListenForTasks(uuid string) error {
 				var ac = cache.NewAgentCache(rmq.config)
 				uuid := ac.GetKeyValue("uuid")
 
-				itr_task := tasks.InstallTestRunTask{
+				itrTask := tasks.InstallTestRunTask{
 					Config: rmq.config,
 				}
 
-				err = json.Unmarshal(d.Body, &itr_task)
+				err = json.Unmarshal(d.Body, &itrTask)
 				// TODO(mierdin): Need to handle this error
 
 				var response responses.SetAgentStatusResponse
 				response.Type = "AgentStatus" //TODO(mierdin): This is an extra step. Maybe a factory function for the task could help here?
-				response.AgentUuid = uuid
-				response.TestUuid = itr_task.Tr.Uuid
+				response.AgentUUID = uuid
+				response.TestUUID = itrTask.Tr.UUID
 
-				err = itr_task.Run()
+				err = itrTask.Run()
 				if err != nil {
 					log.Warning("The InstallTestRun task failed to initialize")
 					response.Status = "fail"
@@ -543,23 +543,23 @@ func (rmq rabbitMQComms) ListenForTasks(uuid string) error {
 				var ac = cache.NewAgentCache(rmq.config)
 				uuid := ac.GetKeyValue("uuid")
 
-				etr_task := tasks.ExecuteTestRunTask{
+				etrTask := tasks.ExecuteTestRunTask{
 					Config: rmq.config,
 				}
 
-				err = json.Unmarshal(d.Body, &etr_task)
+				err = json.Unmarshal(d.Body, &etrTask)
 				// TODO(mierdin): Need to handle this error
 
 				// Send status that the testing has begun, right now.
 				response := responses.SetAgentStatusResponse{
-					TestUuid: etr_task.TestUuid,
+					TestUUID: etrTask.TestUUID,
 					Status:   "testing",
 				}
-				response.AgentUuid = uuid     // TODO(mierdin): Can't declare this in the literal, it's that embedding behavior again. Need to figure this out.
+				response.AgentUUID = uuid     // TODO(mierdin): Can't declare this in the literal, it's that embedding behavior again. Need to figure this out.
 				response.Type = "AgentStatus" //TODO(mierdin): This is an extra step. Maybe a factory function for the task could help here?
 				rmq.SendResponse(response)
 
-				err = etr_task.Run()
+				err = etrTask.Run()
 				if err != nil {
 					log.Warning("The ExecuteTestRun task failed to initialize")
 					response.Status = "fail"
@@ -567,7 +567,7 @@ func (rmq rabbitMQComms) ListenForTasks(uuid string) error {
 				}
 
 			default:
-				log.Errorf(fmt.Sprintf("Unexpected type value for received task: %s", base_msg.Type))
+				log.Errorf(fmt.Sprintf("Unexpected type value for received task: %s", baseMsg.Type))
 			}
 		}
 	}()
@@ -632,7 +632,7 @@ rereg:
 func (rmq rabbitMQComms) ListenForGroupTasks(groupName string, dereg chan bool) error {
 
 	// Connect to RabbitMQ with retry logic
-	conn, err := connectRabbitMQ(rmq.queueUrl)
+	conn, err := connectRabbitMQ(rmq.queueURL)
 	if err != nil {
 		log.Error("(AdvertiseAgent) Failed to connect to RabbitMQ")
 		log.Debug(err)
@@ -683,19 +683,19 @@ func (rmq rabbitMQComms) ListenForGroupTasks(groupName string, dereg chan bool) 
 		for d := range msgs {
 
 			// Unmarshal into BaseTaskMessage to determine type
-			var base_msg tasks.BaseTask
-			err = json.Unmarshal(d.Body, &base_msg)
+			var baseMsg tasks.BaseTask
+			err = json.Unmarshal(d.Body, &baseMsg)
 			// TODO(mierdin): Need to handle this error
 
 			log.Debugf("Agent task received: %s", d.Body)
 
 			// call agent task method based on type
-			switch base_msg.Type {
+			switch baseMsg.Type { // TODO: remove switch?
 
 			// This has been removed, as I am moving away from using queues that use the group name.
 
 			default:
-				log.Errorf(fmt.Sprintf("Unexpected type value for received group task: %s", base_msg.Type))
+				log.Errorf(fmt.Sprintf("Unexpected type value for received group task: %s", baseMsg.Type))
 			}
 		}
 	}()
@@ -712,7 +712,7 @@ func (rmq rabbitMQComms) SendResponse(resp responses.Response) error {
 
 	queueName := "agentresponses"
 
-	conn, err := amqp.Dial(rmq.queueUrl)
+	conn, err := amqp.Dial(rmq.queueURL)
 	if err != nil {
 		log.Error("Failed to connect to RabbitMQ")
 		log.Debug(err)
@@ -770,7 +770,7 @@ func (rmq rabbitMQComms) SendResponse(resp responses.Response) error {
 		return err
 	}
 
-	json_data, err := json.Marshal(resp)
+	jsonData, err := json.Marshal(resp)
 	if err != nil {
 		log.Error("Failed to marshal response data")
 		log.Debug(err)
@@ -784,7 +784,7 @@ func (rmq rabbitMQComms) SendResponse(resp responses.Response) error {
 		false,           // immediate
 		amqp.Publishing{
 			ContentType: "text/plain",
-			Body:        []byte(json_data),
+			Body:        []byte(jsonData),
 		})
 	if err != nil {
 		log.Error("Failed to publish a response onto message queue")
@@ -792,7 +792,7 @@ func (rmq rabbitMQComms) SendResponse(resp responses.Response) error {
 		return err
 	}
 
-	log.Debugf("Sent response to %s: %s", queueName, json_data)
+	log.Debugf("Sent response to %s: %s", queueName, jsonData)
 
 	return nil
 }
@@ -802,7 +802,7 @@ func (rmq rabbitMQComms) ListenForResponses(stopListeningForResponses *chan bool
 
 	queueName := "agentresponses"
 
-	conn, err := amqp.Dial(rmq.queueUrl)
+	conn, err := amqp.Dial(rmq.queueURL)
 	if err != nil {
 		log.Error("Failed to connect to RabbitMQ")
 		log.Debug(err)
@@ -858,8 +858,8 @@ func (rmq rabbitMQComms) ListenForResponses(stopListeningForResponses *chan bool
 		for d := range msgs {
 
 			// Unmarshal into BaseResponse to determine type
-			var base_msg responses.BaseResponse
-			err = json.Unmarshal(d.Body, &base_msg)
+			var baseMsg responses.BaseResponse
+			err = json.Unmarshal(d.Body, &baseMsg)
 			if err != nil {
 				log.Error("Problem unmarshalling baseresponse")
 			}
@@ -867,7 +867,7 @@ func (rmq rabbitMQComms) ListenForResponses(stopListeningForResponses *chan bool
 			log.Debugf("Agent response received: %s", d.Body)
 
 			// call agent response method based on type
-			switch base_msg.Type {
+			switch baseMsg.Type {
 			case "AgentStatus":
 
 				var sasr responses.SetAgentStatusResponse
@@ -876,8 +876,8 @@ func (rmq rabbitMQComms) ListenForResponses(stopListeningForResponses *chan bool
 					log.Error("Problem unmarshalling AgentStatus")
 				}
 
-				log.Debugf("Agent %s is '%s' regarding test %s. Writing to DB.", sasr.AgentUuid, sasr.Status, sasr.TestUuid)
-				err := tdb.SetAgentTestStatus(sasr.TestUuid, sasr.AgentUuid, sasr.Status)
+				log.Debugf("Agent %s is '%s' regarding test %s. Writing to DB.", sasr.AgentUUID, sasr.Status, sasr.TestUUID)
+				err := tdb.SetAgentTestStatus(sasr.TestUUID, sasr.AgentUUID, sasr.Status)
 				if err != nil {
 					log.Errorf("Error writing agent status to DB: %v", err)
 				}
@@ -890,7 +890,7 @@ func (rmq rabbitMQComms) ListenForResponses(stopListeningForResponses *chan bool
 					log.Error("Problem unmarshalling UploadTestDataResponse")
 				}
 
-				err = tdb.SetAgentTestData(utdr.TestUuid, utdr.AgentUuid, utdr.TestData)
+				err = tdb.SetAgentTestData(utdr.TestUUID, utdr.AgentUUID, utdr.TestData)
 				if err != nil {
 					log.Error("Problem setting agent test data")
 				}
@@ -898,17 +898,17 @@ func (rmq rabbitMQComms) ListenForResponses(stopListeningForResponses *chan bool
 				// Send task to the agent that says to delete the entry
 				var dtdt tasks.DeleteTestDataTask
 				dtdt.Type = "DeleteTestData" //TODO(mierdin): This is an extra step. Maybe a factory function for the task could help here?
-				dtdt.TestUuid = utdr.TestUuid
-				rmq.SendTask(utdr.AgentUuid, dtdt)
+				dtdt.TestUUID = utdr.TestUUID
+				rmq.SendTask(utdr.AgentUUID, dtdt)
 
 				// Finally, set the status for this agent in the test to "finished"
-				err := tdb.SetAgentTestStatus(dtdt.TestUuid, utdr.AgentUuid, "finished")
+				err := tdb.SetAgentTestStatus(dtdt.TestUUID, utdr.AgentUUID, "finished")
 				if err != nil {
 					log.Errorf("Error writing agent status to DB: %v", err)
 				}
 
 			default:
-				log.Errorf(fmt.Sprintf("Unexpected type value for received response: %s", base_msg.Type))
+				log.Errorf(fmt.Sprintf("Unexpected type value for received response: %s", baseMsg.Type))
 			}
 		}
 	}()

--- a/db/etcd.go
+++ b/db/etcd.go
@@ -68,7 +68,7 @@ func (etcddb *etcdDB) Init() error {
 // SetAgent will ingest an agent advertisement, and update or insert the agent record
 // in the database as needed.
 func (etcddb *etcdDB) SetAgent(adv defs.AgentAdvert) error {
-	log.Infof("Setting '/todd/agents/%s' key", adv.Uuid)
+	log.Infof("Setting '/todd/agents/%s' key", adv.UUID)
 
 	advJSON, err := json.Marshal(adv)
 	if err != nil {
@@ -79,7 +79,7 @@ func (etcddb *etcdDB) SetAgent(adv defs.AgentAdvert) error {
 	// TODO(mierdin): TTL needs to be user-configurable
 	resp, err := etcddb.keysAPI.Set(
 		context.Background(),                      // context
-		fmt.Sprintf("/todd/agents/%s", adv.Uuid),  // key
+		fmt.Sprintf("/todd/agents/%s", adv.UUID),  // key
 		string(advJSON),                           // value
 		&client.SetOptions{TTL: time.Second * 30}, //optional args
 	)
@@ -130,7 +130,7 @@ func nodeToAgentAdvert(node *client.Node, expectedUUID string) (*defs.AgentAdver
 	adv.Expires = node.TTLDuration()
 
 	// The etcd key should always match the inner JSON
-	if expectedUUID != adv.Uuid {
+	if expectedUUID != adv.UUID {
 		return nil, errors.New("UUID in etcd does not match inner JSON text")
 	}
 
@@ -179,12 +179,12 @@ func (etcddb *etcdDB) GetAgents() ([]defs.AgentAdvert, error) {
 // RemoveAgent will delete an agent advertisement present in etcd. This function exists for the rare situation when
 // an Agent needs to be removed immediately, as opposed to simply waiting for the TTL to expire.
 func (etcddb *etcdDB) RemoveAgent(adv defs.AgentAdvert) error {
-	_, err := etcddb.keysAPI.Delete(context.Background(), fmt.Sprintf("/todd/agents/%s", adv.Uuid), &client.DeleteOptions{Recursive: true, Dir: true})
+	_, err := etcddb.keysAPI.Delete(context.Background(), fmt.Sprintf("/todd/agents/%s", adv.UUID), &client.DeleteOptions{Recursive: true, Dir: true})
 	if err != nil {
 		return err
 	}
 
-	log.Infof("Removed '/todd/agents/%s' key", adv.Uuid)
+	log.Infof("Removed '/todd/agents/%s' key", adv.UUID)
 
 	return nil
 }

--- a/hostresources/crypto.go
+++ b/hostresources/crypto.go
@@ -21,8 +21,8 @@ func GetFileSHA256(filename string) string {
 	hasher := sha256.New()
 	s, err := ioutil.ReadFile(filename)
 	if err != nil {
-		log.Error("Error generating hash for file %s", filename)
-		panic(fmt.Sprintf("Error generating hash for file %s", filename))
+		log.Errorf("Error generating hash for file %s", filename)
+		panic(fmt.Sprintf("Error generating hash for file %s", filename)) // TODO: Use log.Panicf?
 	}
 	hasher.Write(s)
 

--- a/hostresources/uuid.go
+++ b/hostresources/uuid.go
@@ -16,8 +16,6 @@ import (
 	"strconv"
 )
 
-var UUID []byte // TODO: appears to be unused, delete?
-
 var validShortID = regexp.MustCompile("^[a-z0-9]{12}$")
 
 // IsShortID determine if an arbitrary string *looks like* a short ID.

--- a/hostresources/uuid.go
+++ b/hostresources/uuid.go
@@ -16,11 +16,11 @@ import (
 	"strconv"
 )
 
-var UUID []byte
+var UUID []byte // TODO: appears to be unused, delete?
 
 var validShortID = regexp.MustCompile("^[a-z0-9]{12}$")
 
-// Determine if an arbitrary string *looks like* a short ID.
+// IsShortID determine if an arbitrary string *looks like* a short ID.
 func IsShortID(id string) bool {
 	return validShortID.MatchString(id)
 }
@@ -37,8 +37,8 @@ func TruncateID(id string) string {
 	return id[:trimTo]
 }
 
-// GenerateUuid returns an unique id
-func GenerateUuid() string {
+// GenerateUUID returns an unique id
+func GenerateUUID() string {
 	for {
 		id := make([]byte, 32)
 		if _, err := io.ReadFull(rand.Reader, id); err != nil {

--- a/hostresources/uuid_test.go
+++ b/hostresources/uuid_test.go
@@ -15,30 +15,30 @@ import (
 
 // TestGenerateUuid tests that GenerateUuid generates a valid UUID (by length)
 func TestGenerateUuid(t *testing.T) {
-	this_uuid := GenerateUuid()
-	if utf8.RuneCountInString(this_uuid) != 64 {
+	thisUUID := GenerateUUID()
+	if utf8.RuneCountInString(thisUUID) != 64 {
 		t.Fatalf("Invalid UUID generated")
 	}
 }
 
 // TestTruncateID will test that TruncateID properly truncates a UUID
 func TestTruncateID(t *testing.T) {
-	this_uuid := TruncateID("eb00b2a4f7e58ea03e05b81839a72ee810250010aab27431edebb64cb73aae27")
-	if this_uuid != "eb00b2a4f7e5" {
+	thisUUID := TruncateID("eb00b2a4f7e58ea03e05b81839a72ee810250010aab27431edebb64cb73aae27")
+	if thisUUID != "eb00b2a4f7e5" {
 		t.Fatalf("Invalid UUID truncation")
 	}
 }
 
 // TestIsShortIDValid will test to ensure that IsShortIDValid is able to accurately identify a valid shortened UUID
 func TestIsShortIDValid(t *testing.T) {
-	if IsShortID("eb00b2a4f7e5") != true {
+	if !IsShortID("eb00b2a4f7e5") {
 		t.Fatalf("IsShortIDValid is not returning a correct result")
 	}
 }
 
 // TestIsShortIDValid will test to ensure that IsShortIDValid is able to accurately identify an invalid shortened UUID
 func TestIsShortIDInvalid(t *testing.T) {
-	if IsShortID("eb00bxxxxxxxxx2a4f7e5") != false {
+	if IsShortID("eb00bxxxxxxxxx2a4f7e5") {
 		t.Fatalf("IsShortIDValid is not returning a correct result")
 	}
 }

--- a/server/objects/objects.go
+++ b/server/objects/objects.go
@@ -15,7 +15,7 @@ import (
 	log "github.com/Sirupsen/logrus"
 )
 
-// ToddObject is the "base" struct for all objects in ToDD. All metadata shared by all todd objects should be stored here.
+// BaseObject is the "base" struct for all objects in ToDD. All metadata shared by all todd objects should be stored here.
 // Any structs representing todd objects should embed this struct.
 //
 // Generally, since the "Type" field is present in the "parent", or embedded struct, it is appropriate to first unmarshal YAML
@@ -60,34 +60,34 @@ func (b BaseObject) GetLabel() string {
 // a specific ToDD object in the codebase, you should first Unmarshal into the BaseObject struct. Once you have a handle on that, run this struct method, and
 // pass in the original JSON (the "obj_json" param). This will identify the specific type and return that struct to you.
 // TODO(mierdin): Need a better name for this. Change it, then make sure you're replacing all instances of the old name in this file (in several comments)
-func (b BaseObject) ParseToddObject(obj_json []byte) ToddObject {
+func (b BaseObject) ParseToddObject(objJSON []byte) ToddObject {
 
 	// The following chunk of code is designed to re-parse the JSON structure of a ToDD object, now that we know what type it is
 	// (this "Type" field is present in the base BaseObject struct).
-	var finalobj ToddObject
+	var finalObj ToddObject
 	switch b.Type {
 	case "group":
-		var group_obj GroupObject
-		err := json.Unmarshal(obj_json, &group_obj)
+		var groupObj GroupObject
+		err := json.Unmarshal(objJSON, &groupObj)
 		if err != nil {
 			panic(err)
 		}
 
-		finalobj = group_obj
+		finalObj = groupObj
 	case "testrun":
-		var testrun_obj TestRunObject
-		err := json.Unmarshal(obj_json, &testrun_obj)
+		var testrunObj TestRunObject
+		err := json.Unmarshal(objJSON, &testrunObj)
 		if err != nil {
 			panic(err)
 		}
 
-		finalobj = testrun_obj
+		finalObj = testrunObj
 	default:
 		log.Warn("Incorrect object type passed to API")
 		os.Exit(1)
 	}
 
-	return finalobj
+	return finalObj
 }
 
 // ParseToddObjects is similar to the struct ParseToddObject method but is intended to be used when you know the JSON houses a slice/list of Todd Objects.
@@ -95,52 +95,52 @@ func (b BaseObject) ParseToddObject(obj_json []byte) ToddObject {
 // TODO(mierdin): This function is still fairly inflexible, as it assumes that all objects in the JSON are of the same type. Currently, this is a safe bet because
 // the objects API doesn't currently support returning all objects, so they will all be the same type. However, if that changes in the future, this function
 // will have to be refactored.
-func ParseToddObjects(obj_json []byte) []ToddObject {
+func ParseToddObjects(objJSON []byte) []ToddObject {
 
-	var ret_slice []ToddObject
+	var retSlice []ToddObject
 
 	// Marshal API data into object
 	var records []BaseObject
-	err := json.Unmarshal(obj_json, &records)
+	err := json.Unmarshal(objJSON, &records)
 	if err != nil {
 		panic(err)
 	}
 
-	var obj_type string
+	var objType string
 
 	// Return an empty slice since there were no objects in the original JSON
 	if len(records) < 1 {
-		return ret_slice
-	} else {
-		obj_type = records[0].GetType()
+		return retSlice
 	}
 
-	switch obj_type {
+	objType = records[0].GetType()
+
+	switch objType {
 	case "group":
-		var group_objs []GroupObject
-		err := json.Unmarshal(obj_json, &group_objs)
+		var groupObjs []GroupObject
+		err := json.Unmarshal(objJSON, &groupObjs)
 		if err != nil {
 			panic(err)
 		}
 
-		for x := range group_objs {
-			ret_slice = append(ret_slice, group_objs[x])
+		for x := range groupObjs {
+			retSlice = append(retSlice, groupObjs[x])
 		}
 
 	case "testrun":
-		var testrun_objs []TestRunObject
-		err := json.Unmarshal(obj_json, &testrun_objs)
+		var testrunObjs []TestRunObject
+		err := json.Unmarshal(objJSON, &testrunObjs)
 		if err != nil {
 			panic(err)
 		}
 
-		for x := range testrun_objs {
-			ret_slice = append(ret_slice, testrun_objs[x])
+		for x := range testrunObjs {
+			retSlice = append(retSlice, testrunObjs[x])
 		}
 	default:
 		log.Warn("Incorrect object type passed to API")
 		os.Exit(1)
 	}
 
-	return ret_slice
+	return retSlice
 }

--- a/server/tsdb/influxdb.go
+++ b/server/tsdb/influxdb.go
@@ -32,7 +32,7 @@ type influxDB struct {
 
 // WriteData will write the resulting testrun data to influxdb as a batch of points - containing
 // important information like metrics and which agent reported them.
-func (ifdb influxDB) WriteData(testUuid, testRunName, groupName string, testData map[string]map[string]map[string]interface{}) error {
+func (ifdb influxDB) WriteData(testUUID, testRunName, groupName string, testData map[string]map[string]map[string]interface{}) error {
 
 	// Make client
 	c, err := influx.NewHTTPClient(influx.HTTPConfig{
@@ -55,17 +55,17 @@ func (ifdb influxDB) WriteData(testUuid, testRunName, groupName string, testData
 	}
 
 	// Need to publish data from all of the agents that took part in this test
-	for agentUuid, agentData := range testData {
+	for agentUUID, agentData := range testData {
 
 		// Also need to differentiate between the various target that these agents tested against
 		for targetAddress, metrics := range agentData {
 
 			// Create a point and add to batch
 			tags := map[string]string{
-				"agent":       agentUuid,
+				"agent":       agentUUID,
 				"target":      targetAddress,
 				"sourceGroup": groupName,
-				"testUuid":    testUuid,
+				"testUuid":    testUUID,
 			}
 
 			// Insert into influx fields
@@ -91,7 +91,7 @@ func (ifdb influxDB) WriteData(testUuid, testRunName, groupName string, testData
 		return err
 	}
 
-	log.Infof("Wrote test data for %s to influxdb", testUuid)
+	log.Infof("Wrote test data for %s to influxdb", testUUID)
 
 	return nil
 }

--- a/server/tsdb/tsdb.go
+++ b/server/tsdb/tsdb.go
@@ -18,19 +18,19 @@ import (
 	"github.com/toddproject/todd/config"
 )
 
-// TSDBPackage represents all of the behavior that a ToDD TSDB plugin must support
-type TSDBPackage interface {
+// Package represents all of the behavior that a ToDD TSDB plugin must support
+type Package interface {
 	WriteData(string, string, string, map[string]map[string]map[string]interface{}) error
 }
 
 // toddTSDB is a struct to hold anything that satisfies the databasePackage interface
 type toddTSDB struct {
-	TSDBPackage
+	Package
 }
 
-// NewToDDComms will create a new instance of toddTSDB, and load the desired
+// NewToddTSDB will create a new instance of toddTSDB, and load the desired
 // databasePackage-compatible comms package into it.
-func NewToddTSDB(cfg config.Config) *toddTSDB {
+func NewToddTSDB(cfg config.Config) *toddTSDB { // TODO: return Package instead of *struct embedding Package
 
 	// Create toddTSDB instance
 	var tsdb toddTSDB
@@ -38,7 +38,7 @@ func NewToddTSDB(cfg config.Config) *toddTSDB {
 	// Load the appropriate TSDB package based on config file
 	switch cfg.TSDB.Plugin {
 	case "influxdb":
-		tsdb.TSDBPackage = newInfluxDB(cfg)
+		tsdb.Package = newInfluxDB(cfg)
 	default:
 		log.Error("Invalid DB plugin in config file")
 		os.Exit(1)


### PR DESCRIPTION
Mostly removes underscores from variable names and capitalizing acronyms, along with a handful of other fixes.

Also added a few TODOs for items that may need fixing but aren't directly related to linting warnings.