### PR TITLE
Refactor agent/cache package

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,7 +1,7 @@
 {
 	"ImportPath": "github.com/toddproject/todd",
 	"GoVersion": "go1.6",
-	"GodepVersion": "v63",
+	"GodepVersion": "v75",
 	"Packages": [
 		"./..."
 	],
@@ -64,6 +64,11 @@
 			"ImportPath": "github.com/mattn/go-sqlite3",
 			"Comment": "v1.1.0-67-g7204887",
 			"Rev": "7204887cf3a42df1cfaa5505dc3a3427f6dded8b"
+		},
+		{
+			"ImportPath": "github.com/pkg/errors",
+			"Comment": "v0.8.0-2-g248dadf",
+			"Rev": "248dadf4e9068a0b3e79f02ed0a610d935de5302"
 		},
 		{
 			"ImportPath": "github.com/streadway/amqp",

--- a/agent/tasks/deletetestdata.go
+++ b/agent/tasks/deletetestdata.go
@@ -26,10 +26,7 @@ type DeleteTestDataTask struct {
 }
 
 // Run contains the logic necessary to perform this task on the agent.
-func (dtdt DeleteTestDataTask) Run() error {
-
-	var ac = cache.NewAgentCache(dtdt.Config)
-
+func (dtdt DeleteTestDataTask) Run(ac *cache.AgentCache) error {
 	err := ac.DeleteTestRun(dtdt.TestUUID)
 	if err != nil {
 		return fmt.Errorf("DeleteTestDataTask failed - %s", dtdt.TestUUID)

--- a/agent/tasks/downloadasset.go
+++ b/agent/tasks/downloadasset.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 
 	log "github.com/Sirupsen/logrus"
+	"github.com/toddproject/todd/agent/cache"
 )
 
 // DownloadAssetTask defines this particular task. It contains definitions not only for the task message, but
@@ -31,7 +32,7 @@ type DownloadAssetTask struct {
 
 // Run contains the logic necessary to perform this task on the agent. This particular task will download all required assets,
 // copy them into the appropriate directory, and ensure that the execute permission is given to each collector file.
-func (dat DownloadAssetTask) Run() error {
+func (dat DownloadAssetTask) Run(*cache.AgentCache) error {
 
 	// Iterate over the slice of collectors and download them.
 	for x := range dat.Assets {

--- a/agent/tasks/downloadasset_test.go
+++ b/agent/tasks/downloadasset_test.go
@@ -53,7 +53,7 @@ func TestTaskRun(t *testing.T) {
 	}
 
 	// Run task
-	err := task.Run()
+	err := task.Run(nil)
 
 	if err != nil {
 		t.Fatalf("DownloadCollectors failed in some way and wasn't supposed to")

--- a/agent/tasks/executetestrun.go
+++ b/agent/tasks/executetestrun.go
@@ -36,7 +36,7 @@ type ExecuteTestRunTask struct {
 // Run contains the logic necessary to perform this task on the agent. This particular task will execute a
 // testrun that has already been installed into the local agent cache. In this context (single agent),
 // a testrun will be executed once per target, all in parallel.
-func (ett ExecuteTestRunTask) Run() error {
+func (ett ExecuteTestRunTask) Run(ac *cache.AgentCache) error {
 
 	// gatheredData represents test data from this agent for all targets.
 	// Key is target name, value is JSON output from testlet for that target
@@ -54,7 +54,6 @@ func (ett ExecuteTestRunTask) Run() error {
 	time.Sleep(3000 * time.Millisecond)
 
 	// Retrieve test from cache by UUID
-	var ac = cache.NewAgentCache(ett.Config)
 	tr, err := ac.GetTestRun(ett.TestUUID)
 	if err != nil {
 		log.Error(err)

--- a/agent/tasks/installtestrun.go
+++ b/agent/tasks/installtestrun.go
@@ -34,7 +34,7 @@ type InstallTestRunTask struct {
 // The installation procedure will first run the referenced testlet in check mode
 // to help ensure that the actual testrun execution can take place. If that
 // succeeds, the testrun is installed in the agent cache.
-func (itt InstallTestRunTask) Run() error {
+func (itt InstallTestRunTask) Run(ac *cache.AgentCache) error {
 
 	if itt.Tr.Testlet == "" {
 		log.Error("Testlet parameter for this testrun is null")
@@ -67,7 +67,6 @@ func (itt InstallTestRunTask) Run() error {
 	}
 
 	// Insert testrun into agent cache
-	var ac = cache.NewAgentCache(itt.Config)
 	err = ac.InsertTestRun(itt.Tr)
 	if err != nil {
 		log.Error(err)

--- a/agent/tasks/keyvalue.go
+++ b/agent/tasks/keyvalue.go
@@ -27,10 +27,7 @@ type KeyValueTask struct {
 
 // Run contains the logic necessary to perform this task on the agent. This particular task
 // will simply pass a key/value pair to the agent cache to be set
-func (kvt KeyValueTask) Run() error {
-
-	var ac = cache.NewAgentCache(kvt.Config)
-
+func (kvt KeyValueTask) Run(ac *cache.AgentCache) error {
 	err := ac.SetKeyValue(kvt.Key, kvt.Value)
 	if err != nil {
 		return fmt.Errorf("KeyValueTask failed - %s:%s", kvt.Key, kvt.Value)

--- a/agent/tasks/setgroup.go
+++ b/agent/tasks/setgroup.go
@@ -27,12 +27,14 @@ type SetGroupTask struct {
 // TODO (mierdin): Could this not be condensed with the generic "keyvalue" task?
 
 // Run contains the logic necessary to perform this task on the agent.
-func (sgt SetGroupTask) Run() error {
-
-	var ac = cache.NewAgentCache(sgt.Config)
-
+func (sgt SetGroupTask) Run(ac *cache.AgentCache) error {
 	// First, see what the current group is. If it matches what this task is instructing, we don't need to do anything.
-	if ac.GetKeyValue("group") != sgt.GroupName {
+	groupName, err := ac.GetKeyValue("group")
+	if err != nil {
+		return err
+	}
+
+	if groupName != sgt.GroupName {
 		err := ac.SetKeyValue("group", sgt.GroupName)
 		if err != nil {
 			return fmt.Errorf("Failed to set keyvalue pair - %s:%s", "group", sgt.GroupName)

--- a/agent/tasks/tasks.go
+++ b/agent/tasks/tasks.go
@@ -11,6 +11,8 @@ package tasks
 import (
 	"io"
 	"os"
+
+	"github.com/toddproject/todd/agent/cache"
 )
 
 // Task is an interface to define task behavior This is used for functions like those in comms
@@ -20,7 +22,7 @@ type Task interface {
 	// TODO(mierdin): This works but is a little "meh". Basically, each task has to have a "Run()" function, as enforced
 	// by this interface. If the task needs some additional data, it gets these through struct properties. This works but
 	// doesn't quite feel right. Come back to this and see if there's a better way.
-	Run() error
+	Run(*cache.AgentCache) error
 }
 
 // BaseTask is a struct that is intended to be embedded by specific task structs. Both of these in conjunction

--- a/cmd/todd-agent/main.go
+++ b/cmd/todd-agent/main.go
@@ -57,20 +57,26 @@ func main() {
 	}
 
 	// Set up cache
-	var ac = cache.NewAgentCache(cfg)
-	ac.Init()
+	ac, err := cache.New(cfg)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer ac.Close()
 
 	// Generate UUID
 	uuid := hostresources.GenerateUUID()
-	ac.SetKeyValue("uuid", uuid)
+	err = ac.SetKeyValue("uuid", uuid)
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	log.Infof("ToDD Agent Activated: %s", uuid)
 
 	// Start test data reporting service
-	go watchForFinishedTestRuns(cfg)
+	go watchForFinishedTestRuns(cfg, ac)
 
 	// Construct comms package
-	tc, err := comms.NewToDDComms(cfg)
+	tc, err := comms.NewAgentComms(cfg, ac)
 	if err != nil {
 		os.Exit(1)
 	}
@@ -126,11 +132,11 @@ func main() {
 // It will periodically look at the table and send any present test data back to the server as a response.
 // When the server has successfully received this data, it will send a task back to this specific agent
 // to delete this row from the cache.
-func watchForFinishedTestRuns(cfg config.Config) error {
-
-	var ac = cache.NewAgentCache(cfg)
-
-	agentUUID := ac.GetKeyValue("uuid")
+func watchForFinishedTestRuns(cfg config.Config, ac *cache.AgentCache) error {
+	agentUUID, err := ac.GetKeyValue("uuid")
+	if err != nil {
+		return err
+	}
 
 	for {
 

--- a/comms/comms.go
+++ b/comms/comms.go
@@ -15,6 +15,7 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 
+	"github.com/toddproject/todd/agent/cache"
 	"github.com/toddproject/todd/agent/defs"
 	"github.com/toddproject/todd/agent/responses"
 	"github.com/toddproject/todd/agent/tasks"
@@ -47,12 +48,16 @@ type Package interface {
 	SendTask(string, tasks.Task) error
 
 	// watches for new group membership instructions in the cache and reregisters
-	WatchForGroup()
+	WatchForGroup() error
 
 	ListenForGroupTasks(string, chan bool) error
 
 	ListenForResponses(*chan bool) error
 	SendResponse(responses.Response) error
+
+	// adds a cache agent to the comms package. temporary until
+	// comms package is refactored
+	setAgentCache(*cache.AgentCache)
 }
 
 // toddComms is a struct to hold anything that satisfies the CommsPackage interface
@@ -77,4 +82,15 @@ func NewToDDComms(cfg config.Config) (*toddComms, error) { // TODO: Return Packa
 
 	return &tc, nil
 
+}
+
+// NewAgentComms returns a comms instance configured for agent usages.
+//
+// TODO: accept an interface for cache instead of concrete type
+func NewAgentComms(cfg config.Config, ac *cache.AgentCache) (*toddComms, error) {
+	comms, err := NewToDDComms(cfg)
+	if err == nil {
+		comms.setAgentCache(ac)
+	}
+	return comms, err
 }

--- a/vendor/github.com/pkg/errors/.gitignore
+++ b/vendor/github.com/pkg/errors/.gitignore
@@ -1,0 +1,24 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof

--- a/vendor/github.com/pkg/errors/.travis.yml
+++ b/vendor/github.com/pkg/errors/.travis.yml
@@ -1,0 +1,11 @@
+language: go
+go_import_path: github.com/pkg/errors
+go:
+  - 1.4.3
+  - 1.5.4
+  - 1.6.3
+  - 1.7.3
+  - tip
+
+script:
+  - go test -v ./...

--- a/vendor/github.com/pkg/errors/LICENSE
+++ b/vendor/github.com/pkg/errors/LICENSE
@@ -1,0 +1,23 @@
+Copyright (c) 2015, Dave Cheney <dave@cheney.net>
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/github.com/pkg/errors/README.md
+++ b/vendor/github.com/pkg/errors/README.md
@@ -1,0 +1,52 @@
+# errors [![Travis-CI](https://travis-ci.org/pkg/errors.svg)](https://travis-ci.org/pkg/errors) [![AppVeyor](https://ci.appveyor.com/api/projects/status/b98mptawhudj53ep/branch/master?svg=true)](https://ci.appveyor.com/project/davecheney/errors/branch/master) [![GoDoc](https://godoc.org/github.com/pkg/errors?status.svg)](http://godoc.org/github.com/pkg/errors) [![Report card](https://goreportcard.com/badge/github.com/pkg/errors)](https://goreportcard.com/report/github.com/pkg/errors)
+
+Package errors provides simple error handling primitives.
+
+`go get github.com/pkg/errors`
+
+The traditional error handling idiom in Go is roughly akin to
+```go
+if err != nil {
+        return err
+}
+```
+which applied recursively up the call stack results in error reports without context or debugging information. The errors package allows programmers to add context to the failure path in their code in a way that does not destroy the original value of the error.
+
+## Adding context to an error
+
+The errors.Wrap function returns a new error that adds context to the original error. For example
+```go
+_, err := ioutil.ReadAll(r)
+if err != nil {
+        return errors.Wrap(err, "read failed")
+}
+```
+## Retrieving the cause of an error
+
+Using `errors.Wrap` constructs a stack of errors, adding context to the preceding error. Depending on the nature of the error it may be necessary to reverse the operation of errors.Wrap to retrieve the original error for inspection. Any error value which implements this interface can be inspected by `errors.Cause`.
+```go
+type causer interface {
+        Cause() error
+}
+```
+`errors.Cause` will recursively retrieve the topmost error which does not implement `causer`, which is assumed to be the original cause. For example:
+```go
+switch err := errors.Cause(err).(type) {
+case *MyError:
+        // handle specifically
+default:
+        // unknown error
+}
+```
+
+[Read the package documentation for more information](https://godoc.org/github.com/pkg/errors).
+
+## Contributing
+
+We welcome pull requests, bug fixes and issue reports. With that said, the bar for adding new symbols to this package is intentionally set high.
+
+Before proposing a change, please discuss your change by raising an issue.
+
+## Licence
+
+BSD-2-Clause

--- a/vendor/github.com/pkg/errors/appveyor.yml
+++ b/vendor/github.com/pkg/errors/appveyor.yml
@@ -1,0 +1,32 @@
+version: build-{build}.{branch}
+
+clone_folder: C:\gopath\src\github.com\pkg\errors
+shallow_clone: true # for startup speed
+
+environment:
+  GOPATH: C:\gopath
+
+platform:
+  - x64
+
+# http://www.appveyor.com/docs/installed-software
+install:
+  # some helpful output for debugging builds
+  - go version
+  - go env
+  # pre-installed MinGW at C:\MinGW is 32bit only
+  # but MSYS2 at C:\msys64 has mingw64
+  - set PATH=C:\msys64\mingw64\bin;%PATH%
+  - gcc --version
+  - g++ --version
+
+build_script:
+  - go install -v ./...
+
+test_script:
+  - set PATH=C:\gopath\bin;%PATH%
+  - go test -v ./...
+
+#artifacts:
+#  - path: '%GOPATH%\bin\*.exe'
+deploy: off

--- a/vendor/github.com/pkg/errors/errors.go
+++ b/vendor/github.com/pkg/errors/errors.go
@@ -1,0 +1,269 @@
+// Package errors provides simple error handling primitives.
+//
+// The traditional error handling idiom in Go is roughly akin to
+//
+//     if err != nil {
+//             return err
+//     }
+//
+// which applied recursively up the call stack results in error reports
+// without context or debugging information. The errors package allows
+// programmers to add context to the failure path in their code in a way
+// that does not destroy the original value of the error.
+//
+// Adding context to an error
+//
+// The errors.Wrap function returns a new error that adds context to the
+// original error by recording a stack trace at the point Wrap is called,
+// and the supplied message. For example
+//
+//     _, err := ioutil.ReadAll(r)
+//     if err != nil {
+//             return errors.Wrap(err, "read failed")
+//     }
+//
+// If additional control is required the errors.WithStack and errors.WithMessage
+// functions destructure errors.Wrap into its component operations of annotating
+// an error with a stack trace and an a message, respectively.
+//
+// Retrieving the cause of an error
+//
+// Using errors.Wrap constructs a stack of errors, adding context to the
+// preceding error. Depending on the nature of the error it may be necessary
+// to reverse the operation of errors.Wrap to retrieve the original error
+// for inspection. Any error value which implements this interface
+//
+//     type causer interface {
+//             Cause() error
+//     }
+//
+// can be inspected by errors.Cause. errors.Cause will recursively retrieve
+// the topmost error which does not implement causer, which is assumed to be
+// the original cause. For example:
+//
+//     switch err := errors.Cause(err).(type) {
+//     case *MyError:
+//             // handle specifically
+//     default:
+//             // unknown error
+//     }
+//
+// causer interface is not exported by this package, but is considered a part
+// of stable public API.
+//
+// Formatted printing of errors
+//
+// All error values returned from this package implement fmt.Formatter and can
+// be formatted by the fmt package. The following verbs are supported
+//
+//     %s    print the error. If the error has a Cause it will be
+//           printed recursively
+//     %v    see %s
+//     %+v   extended format. Each Frame of the error's StackTrace will
+//           be printed in detail.
+//
+// Retrieving the stack trace of an error or wrapper
+//
+// New, Errorf, Wrap, and Wrapf record a stack trace at the point they are
+// invoked. This information can be retrieved with the following interface.
+//
+//     type stackTracer interface {
+//             StackTrace() errors.StackTrace
+//     }
+//
+// Where errors.StackTrace is defined as
+//
+//     type StackTrace []Frame
+//
+// The Frame type represents a call site in the stack trace. Frame supports
+// the fmt.Formatter interface that can be used for printing information about
+// the stack trace of this error. For example:
+//
+//     if err, ok := err.(stackTracer); ok {
+//             for _, f := range err.StackTrace() {
+//                     fmt.Printf("%+s:%d", f)
+//             }
+//     }
+//
+// stackTracer interface is not exported by this package, but is considered a part
+// of stable public API.
+//
+// See the documentation for Frame.Format for more details.
+package errors
+
+import (
+	"fmt"
+	"io"
+)
+
+// New returns an error with the supplied message.
+// New also records the stack trace at the point it was called.
+func New(message string) error {
+	return &fundamental{
+		msg:   message,
+		stack: callers(),
+	}
+}
+
+// Errorf formats according to a format specifier and returns the string
+// as a value that satisfies error.
+// Errorf also records the stack trace at the point it was called.
+func Errorf(format string, args ...interface{}) error {
+	return &fundamental{
+		msg:   fmt.Sprintf(format, args...),
+		stack: callers(),
+	}
+}
+
+// fundamental is an error that has a message and a stack, but no caller.
+type fundamental struct {
+	msg string
+	*stack
+}
+
+func (f *fundamental) Error() string { return f.msg }
+
+func (f *fundamental) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		if s.Flag('+') {
+			io.WriteString(s, f.msg)
+			f.stack.Format(s, verb)
+			return
+		}
+		fallthrough
+	case 's':
+		io.WriteString(s, f.msg)
+	case 'q':
+		fmt.Fprintf(s, "%q", f.msg)
+	}
+}
+
+// WithStack annotates err with a stack trace at the point WithStack was called.
+// If err is nil, WithStack returns nil.
+func WithStack(err error) error {
+	if err == nil {
+		return nil
+	}
+	return &withStack{
+		err,
+		callers(),
+	}
+}
+
+type withStack struct {
+	error
+	*stack
+}
+
+func (w *withStack) Cause() error { return w.error }
+
+func (w *withStack) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		if s.Flag('+') {
+			fmt.Fprintf(s, "%+v", w.Cause())
+			w.stack.Format(s, verb)
+			return
+		}
+		fallthrough
+	case 's':
+		io.WriteString(s, w.Error())
+	case 'q':
+		fmt.Fprintf(s, "%q", w.Error())
+	}
+}
+
+// Wrap returns an error annotating err with a stack trace
+// at the point Wrap is called, and the supplied message.
+// If err is nil, Wrap returns nil.
+func Wrap(err error, message string) error {
+	if err == nil {
+		return nil
+	}
+	err = &withMessage{
+		cause: err,
+		msg:   message,
+	}
+	return &withStack{
+		err,
+		callers(),
+	}
+}
+
+// Wrapf returns an error annotating err with a stack trace
+// at the point Wrapf is call, and the format specifier.
+// If err is nil, Wrapf returns nil.
+func Wrapf(err error, format string, args ...interface{}) error {
+	if err == nil {
+		return nil
+	}
+	err = &withMessage{
+		cause: err,
+		msg:   fmt.Sprintf(format, args...),
+	}
+	return &withStack{
+		err,
+		callers(),
+	}
+}
+
+// WithMessage annotates err with a new message.
+// If err is nil, WithMessage returns nil.
+func WithMessage(err error, message string) error {
+	if err == nil {
+		return nil
+	}
+	return &withMessage{
+		cause: err,
+		msg:   message,
+	}
+}
+
+type withMessage struct {
+	cause error
+	msg   string
+}
+
+func (w *withMessage) Error() string { return w.msg + ": " + w.cause.Error() }
+func (w *withMessage) Cause() error  { return w.cause }
+
+func (w *withMessage) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		if s.Flag('+') {
+			fmt.Fprintf(s, "%+v\n", w.Cause())
+			io.WriteString(s, w.msg)
+			return
+		}
+		fallthrough
+	case 's', 'q':
+		io.WriteString(s, w.Error())
+	}
+}
+
+// Cause returns the underlying cause of the error, if possible.
+// An error value has a cause if it implements the following
+// interface:
+//
+//     type causer interface {
+//            Cause() error
+//     }
+//
+// If the error does not implement Cause, the original error will
+// be returned. If the error is nil, nil will be returned without further
+// investigation.
+func Cause(err error) error {
+	type causer interface {
+		Cause() error
+	}
+
+	for err != nil {
+		cause, ok := err.(causer)
+		if !ok {
+			break
+		}
+		err = cause.Cause()
+	}
+	return err
+}

--- a/vendor/github.com/pkg/errors/stack.go
+++ b/vendor/github.com/pkg/errors/stack.go
@@ -1,0 +1,178 @@
+package errors
+
+import (
+	"fmt"
+	"io"
+	"path"
+	"runtime"
+	"strings"
+)
+
+// Frame represents a program counter inside a stack frame.
+type Frame uintptr
+
+// pc returns the program counter for this frame;
+// multiple frames may have the same PC value.
+func (f Frame) pc() uintptr { return uintptr(f) - 1 }
+
+// file returns the full path to the file that contains the
+// function for this Frame's pc.
+func (f Frame) file() string {
+	fn := runtime.FuncForPC(f.pc())
+	if fn == nil {
+		return "unknown"
+	}
+	file, _ := fn.FileLine(f.pc())
+	return file
+}
+
+// line returns the line number of source code of the
+// function for this Frame's pc.
+func (f Frame) line() int {
+	fn := runtime.FuncForPC(f.pc())
+	if fn == nil {
+		return 0
+	}
+	_, line := fn.FileLine(f.pc())
+	return line
+}
+
+// Format formats the frame according to the fmt.Formatter interface.
+//
+//    %s    source file
+//    %d    source line
+//    %n    function name
+//    %v    equivalent to %s:%d
+//
+// Format accepts flags that alter the printing of some verbs, as follows:
+//
+//    %+s   path of source file relative to the compile time GOPATH
+//    %+v   equivalent to %+s:%d
+func (f Frame) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 's':
+		switch {
+		case s.Flag('+'):
+			pc := f.pc()
+			fn := runtime.FuncForPC(pc)
+			if fn == nil {
+				io.WriteString(s, "unknown")
+			} else {
+				file, _ := fn.FileLine(pc)
+				fmt.Fprintf(s, "%s\n\t%s", fn.Name(), file)
+			}
+		default:
+			io.WriteString(s, path.Base(f.file()))
+		}
+	case 'd':
+		fmt.Fprintf(s, "%d", f.line())
+	case 'n':
+		name := runtime.FuncForPC(f.pc()).Name()
+		io.WriteString(s, funcname(name))
+	case 'v':
+		f.Format(s, 's')
+		io.WriteString(s, ":")
+		f.Format(s, 'd')
+	}
+}
+
+// StackTrace is stack of Frames from innermost (newest) to outermost (oldest).
+type StackTrace []Frame
+
+func (st StackTrace) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		switch {
+		case s.Flag('+'):
+			for _, f := range st {
+				fmt.Fprintf(s, "\n%+v", f)
+			}
+		case s.Flag('#'):
+			fmt.Fprintf(s, "%#v", []Frame(st))
+		default:
+			fmt.Fprintf(s, "%v", []Frame(st))
+		}
+	case 's':
+		fmt.Fprintf(s, "%s", []Frame(st))
+	}
+}
+
+// stack represents a stack of program counters.
+type stack []uintptr
+
+func (s *stack) Format(st fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		switch {
+		case st.Flag('+'):
+			for _, pc := range *s {
+				f := Frame(pc)
+				fmt.Fprintf(st, "\n%+v", f)
+			}
+		}
+	}
+}
+
+func (s *stack) StackTrace() StackTrace {
+	f := make([]Frame, len(*s))
+	for i := 0; i < len(f); i++ {
+		f[i] = Frame((*s)[i])
+	}
+	return f
+}
+
+func callers() *stack {
+	const depth = 32
+	var pcs [depth]uintptr
+	n := runtime.Callers(3, pcs[:])
+	var st stack = pcs[0:n]
+	return &st
+}
+
+// funcname removes the path prefix component of a function's name reported by func.Name().
+func funcname(name string) string {
+	i := strings.LastIndex(name, "/")
+	name = name[i+1:]
+	i = strings.Index(name, ".")
+	return name[i+1:]
+}
+
+func trimGOPATH(name, file string) string {
+	// Here we want to get the source file path relative to the compile time
+	// GOPATH. As of Go 1.6.x there is no direct way to know the compiled
+	// GOPATH at runtime, but we can infer the number of path segments in the
+	// GOPATH. We note that fn.Name() returns the function name qualified by
+	// the import path, which does not include the GOPATH. Thus we can trim
+	// segments from the beginning of the file path until the number of path
+	// separators remaining is one more than the number of path separators in
+	// the function name. For example, given:
+	//
+	//    GOPATH     /home/user
+	//    file       /home/user/src/pkg/sub/file.go
+	//    fn.Name()  pkg/sub.Type.Method
+	//
+	// We want to produce:
+	//
+	//    pkg/sub/file.go
+	//
+	// From this we can easily see that fn.Name() has one less path separator
+	// than our desired output. We count separators from the end of the file
+	// path until it finds two more than in the function name and then move
+	// one character forward to preserve the initial path segment without a
+	// leading separator.
+	const sep = "/"
+	goal := strings.Count(name, sep) + 2
+	i := len(file)
+	for n := 0; n < goal; n++ {
+		i = strings.LastIndex(file[:i], sep)
+		if i == -1 {
+			// not enough separators found, set i so that the slice expression
+			// below leaves file unmodified
+			i = -len(sep)
+			break
+		}
+	}
+	// get back to 0 or trim the leading separator
+	file = file[i+len(sep):]
+	return file
+}


### PR DESCRIPTION
* Began converting over to use `github.com/pkg/errors` as discussed in #82.
* Additional error handling added.
* Replaced path formatting via `fmt.Sprintf` with `filepath.Join`, which handles cross-platform paths.
* `AgentCache` only opens the database once at start instead of on every call. ([`sql.DB`](https://golang.org/pkg/database/sql/#DB) is a connection pool safe for concurrent use.)
* `AgentCache` is initialized in `cmd/todd-agent/main.go` and injected into functions/objects which require it, namely `Task.Run()`. As a temporary measure, the `setAgentCache()` method was added to the `comms` package so todd-agent can inject the `AgentCache`. This is to avoid too many change in this patch and is removed in a later patch where task handling is largely extracted from `comms`.
* Combined `NewAgentCache()` and `AgentCache.Init()` into `New()`.
  * Usage appears as `cache.New(cfg)` instead of `cache.NewAgentCache()`, this is recommended when a package only exports one type. (As mentioned in [Effective Go](https://golang.org/doc/effective_go.html#package-names).)

    > the function to make new instances of ring.Ring—which is the definition of a constructor in Go—would normally be called NewRing, but since Ring is the only type exported by the package, and since the package is called ring, it's called just New, which clients of the package see as ring.New.

  * The two steps were combined as there is no case of creating an `AgentCache` and not immediately initializing it.
* SQL statements have been reformatted with SQL identifiers in upper case.
* String formatting in SQL statements replaced with parameterized queries.
* More efficient row counting in `AgentCache.SetKeyValue()`.