### PR TITLE
Added linting capabilities and fixed 'make test'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,10 @@ fmt:
 
 test: 
 	go test ./... -cover
+	scripts/start-containers.sh integration
+
+lint:
+	scripts/lint.sh
 
 update_deps:
 	go get -u github.com/tools/godep

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,6 +1,5 @@
 # Install dependencies
-go get -u github.com/golang/lint/golint
 go get -u github.com/alecthomas/gometalinter
 
 # Lint checks, skipping vendor and assets directory
-gometalinter --disable-all --enable=golint --skip=assets --vendor ./...
+gometalinter --install --disable-all --enable=golint --skip=assets --vendor ./...

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,5 +1,6 @@
 # Install dependencies
 go get -u github.com/alecthomas/gometalinter
+gometalinter --install > /dev/null
 
 # Lint checks, skipping vendor and assets directory
-gometalinter --install --disable-all --enable=golint --skip=assets --vendor ./...
+gometalinter --disable-all --enable=golint --skip=assets --vendor ./...

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,0 +1,6 @@
+# Install dependencies
+go get -u github.com/golang/lint/golint
+go get -u github.com/alecthomas/gometalinter
+
+# Lint checks, skipping vendor and assets directory
+gometalinter --disable-all --enable=golint --skip=assets --vendor ./...

--- a/scripts/start-containers.sh
+++ b/scripts/start-containers.sh
@@ -15,6 +15,12 @@ branch=${branch:-HEAD}
 
 toddimage=toddproject/todd:$branch
 
+if [ ${PWD:(-7)} == "scripts" ]
+then
+    echo "Please do not run this script directly - use the makefile in the main repo."
+    exit 1
+fi
+
 function dtodd {
     docker run --rm --net todd-network --name="todd-client" $toddimage todd --host="todd-server.todd-network" "$@"
     sleep 5
@@ -106,8 +112,9 @@ function itsetup {
         testrun-inttest-http.yml \
     )
 
+    echo "Uploading YAML definitions..."
     for i in ${yaml_files[@]}; do
-        cat $DIR/../docs/dsl/integration/${i} | docker run -i --rm --net todd-network --name="todd-client" $toddimage todd --host="todd-server.todd-network" create
+        cat $DIR/../docs/dsl/integration/${i} | docker run -i --rm --net todd-network --name="todd-client" $toddimage todd --host="todd-server.todd-network" create > /dev/null
     done
 }
 
@@ -166,7 +173,7 @@ startinfra
 if [ -n "$1" ]
 then
     echo "Performing 'docker build'..."
-    docker build -t toddproject/todd:$branch -f ../Dockerfile .. > /dev/null
+    docker build -t toddproject/todd:$branch -f ./Dockerfile . > /dev/null
 
     if [ $? != 0 ]
     then


### PR DESCRIPTION
As mentioned in https://github.com/toddproject/todd/pull/124, linting checks are needed - so this PR adds some basic linting checks to the makefile.

It also unifies unit and e2e testing underneath `make test` command.

Closes https://github.com/toddproject/todd/issues/128