### PR TITLE
Refactor agent/facts

### DIFF
--- a/cmd/todd-agent/main.go
+++ b/cmd/todd-agent/main.go
@@ -107,18 +107,24 @@ func main() {
 			defaultaddr = hostresources.GetIPOfInt(cfg.LocalResources.DefaultInterface).String()
 		}
 
+		fcts, err := facts.GetFacts(cfg)
+		if err != nil {
+			log.Errorf("Error gathering facts: %v", err)
+			continue
+		}
+
 		// Create an AgentAdvert instance to represent this particular agent
 		me := defs.AgentAdvert{
 			UUID:           uuid,
 			DefaultAddr:    defaultaddr,
 			FactCollectors: gatheredAssets["factcollectors"],
 			Testlets:       gatheredAssets["testlets"],
-			Facts:          facts.GetFacts(cfg),
+			Facts:          fcts,
 			LocalTime:      time.Now().UTC(),
 		}
 
 		// Advertise this agent
-		err := tc.Package.AdvertiseAgent(me)
+		err = tc.Package.AdvertiseAgent(me)
 		if err != nil {
 			log.Error("Failed to advertise agent after several retries")
 		}


### PR DESCRIPTION
* Additional error handling.
* Use `filepath.Join()` for better cross-platform support.
* Split script collection from script execution.

Other thoughts:
* Could reuse a single `bytes.Buffer` to execute each script, resetting between calls, to reduce memory usage/GC pressure. Went with the simple call to `cmd.Output()` as it seemed most clear and sharing a buffer wouldn't work with concurrency (if added in future).
* Could execute the scripts concurrently, but I'm not sure they're currently slow so it seemed like unnecessary complexity.